### PR TITLE
fix(ci): only deploy to Vercel when landing/ changes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- landing/"
+}


### PR DESCRIPTION
## What
  Adds a `vercel.json` that tells Vercel to only build when files inside `landing/` change.

  ## Why
  Without this, Vercel triggers a build on every push — including Electron app changes
  that have nothing to do with the landing page. This adds CI noise and wastes build minutes.

  ## Changes
  - `vercel.json` (new): sets `ignoreCommand` to a `git diff` scoped to `landing/` —
    exits 0 (skip) when no landing changes detected, exits 1 (proceed) when they are

  ## Testing
  1. Push a commit touching only Electron source (`src/`, `package.json`) — Vercel skips
  2. Push a commit touching any file under `landing/` — Vercel builds