### PR TITLE
Sprint/v1.2.0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "skills": {
+    "paths": [".claude/skills"]
+  }
+}

--- a/.claude/skills/commit-msg.md
+++ b/.claude/skills/commit-msg.md
@@ -1,0 +1,141 @@
+# Commit Message Protocol
+
+Drafts a correctly structured commit message for this project. Invoke after completing
+a unit of work and before running `git commit`.
+
+Triggered by: `/commit-msg`
+
+---
+
+## Message structure
+
+### Subject line
+```
+type(scope): imperative summary in present tense
+```
+- Max 72 characters
+- Imperative mood: "add", "fix", "update" — not "added", "fixing", "updates"
+- Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `review`
+- Scope: the subsystem, component, or file area affected (e.g. `ptt`, `panel`, `settings`)
+- No trailing period
+- **Never** include `Co-Authored-By` lines
+
+### Body format
+- Leave one blank line between subject and body
+- Group related changes under a plain-text **section label** followed by a colon
+  (e.g. `Cursor companion:`, `Settings store:`, `Voice catalogue:`)
+- Each point starts with `- ` and uses an em dash `—` to separate the change
+  from its rationale or mechanism
+- Explain the **why** and **how**, not just the what
+- Wrap all lines at ~72 characters
+- Separate section groups with a blank line
+- No bullet sub-nesting — keep it flat
+
+### What belongs in the body
+- Non-obvious decisions or constraints
+- Failure modes the change addresses
+- Subtle invariants a future reader would need to understand the diff
+- Anything that would look arbitrary without context
+
+### What does NOT belong
+- Restatement of what the diff already shows
+- References to the current task, issue number, or caller
+  ("added for the X flow", "handles the case from issue #123") — these rot
+- `Co-Authored-By` lines — ever
+
+---
+
+## Step 1 — Gather context
+
+Run the following to understand what changed:
+```
+git diff --cached --stat
+git diff --cached
+git status
+```
+
+If nothing is staged, note it and ask the developer which files to include before drafting.
+
+---
+
+## Step 2 — Draft the message
+
+Using the structure above, produce a complete commit message. Show it in a code block
+so the developer can copy it directly.
+
+### Choosing the type
+| Situation | Type |
+|-----------|------|
+| New user-facing capability | `feat` |
+| Bug fix or regression | `fix` |
+| Build, tooling, deps, version bumps | `chore` |
+| Documentation only | `docs` |
+| Internal restructure, no behaviour change | `refactor` |
+| Code review follow-up changes | `review` |
+
+### Choosing the scope
+Use the primary subsystem or component name affected. Examples from this codebase:
+`ptt`, `panel`, `overlay`, `settings`, `voice`, `chats`, `cursor`, `ipc`, `types`, `build`
+
+If multiple unrelated subsystems changed, consider whether this should be split into
+multiple commits. If the changes are coherent, use the broadest accurate scope or omit
+scope parentheses.
+
+---
+
+## Step 3 — Validate before presenting
+
+Self-check before showing the draft:
+- [ ] Subject ≤ 72 characters
+- [ ] Present tense imperative subject
+- [ ] No `Co-Authored-By` line present
+- [ ] Body lines wrap at ~72 characters
+- [ ] Rationale present for any non-obvious change (em dash format)
+- [ ] No task/issue references in the body
+- [ ] Section labels are plain text (no `##` markdown headers)
+
+---
+
+## Step 4 — Present and iterate
+
+Show the draft. Ask: "Does this capture everything, or should any section be adjusted?"
+
+If the developer requests changes, revise and re-validate before presenting again.
+
+---
+
+## Example (from this project's git history)
+
+```
+feat(sprint/v1.3.0): cursor companion, voice catalogue, chat export
+
+Cursor companion:
+- Add CursorCompanion.tsx — floats near the system cursor so the
+  overlay stays visible without covering active UI elements.
+- Wire IPC channel for position updates — renderer polls on a 100ms
+  interval to keep latency imperceptible without saturating the main
+  process.
+
+Voice catalogue:
+- Extend VoiceTab with per-voice preview — lets users audition a voice
+  before committing; avoids settings round-trips.
+- Add voice metadata to shared types — ElevenLabs model ID and category
+  fields needed downstream for the API call builder.
+
+Chat export:
+- Add export-to-clipboard action in ChatsTab — markdown format chosen
+  for portability; plain text would lose structural context.
+- Persist export timestamp in settings-store — prevents duplicate
+  exports on accidental re-trigger.
+```
+
+---
+
+## Hard constraints (always enforce)
+
+- **Never include `Co-Authored-By`** — this project explicitly prohibits it
+- **Never generate a subject line over 72 characters** — truncate scope or
+  rephrase rather than exceed the limit
+- **Never use markdown in the commit body** — no `##`, `**bold**`, or backtick
+  code fences; plain text only
+- **Never reference issue numbers, PR numbers, or task IDs** in the body

--- a/.claude/skills/merge-flow.md
+++ b/.claude/skills/merge-flow.md
@@ -1,0 +1,99 @@
+# Merge Flow Protocol
+
+Enforces the project's GitFlow PR routing rules. Invoke before opening any pull request
+or when unsure where a branch should target.
+
+Triggered by: `/merge-flow`
+
+---
+
+## Routing rules (canonical)
+
+```
+feature/*   →  dev        (integration; all features stabilise here)
+fix/*        →  master     (hotfix) + dev  (backport)
+sprint/vX   →  dev        (then dev → master via release/*)
+release/vX  →  master     (tagged) + dev
+dev         →  master     (via release/* only — never direct)
+```
+
+**master is a production release trigger, not an integration branch.**
+Every merge to master = a versioned installer build fires in CI.
+The project head gates master exclusively via PR review.
+
+---
+
+## Step 1 — Identify current branch
+
+Run: `git rev-parse --abbrev-ref HEAD`
+
+Classify the branch by prefix:
+
+| Branch pattern | Correct PR target | Notes |
+|----------------|-------------------|-------|
+| `feature/*`    | `dev`             | Standard feature work |
+| `sprint/vX.X.X`| `dev`             | Port/selective rebase off master |
+| `fix/*`        | `master` + `dev`  | Hotfix: merge to master (tagged), backport to dev |
+| `release/vX.X.X`| `master` + `dev` | RC branch: merge to master (tagged), sync dev |
+| `dev`          | Never directly    | Only via a `release/*` branch |
+| `master`       | Never             | Production; no outbound PRs |
+| anything else  | Warn + confirm    | Non-standard name — clarify intent |
+
+---
+
+## Step 2 — Validate the target
+
+If the developer states or implies a PR target, check it against the table above.
+
+### If target is correct:
+Confirm: "Branch `[name]` → `[target]` is correct per GitFlow rules. Proceed."
+
+### If target is `master` and branch is NOT `fix/*` or `release/*`:
+Block and warn:
+> "Direct merge to master is not allowed for `[branch-type]` branches.
+> master is a production release trigger gated by the project head.
+> Correct target for `[branch]` is `dev`.
+> Open the PR against `dev` instead."
+
+### If target is `dev` and branch is `fix/*`:
+Warn:
+> "Hotfixes must merge to `master` first (with a version tag), then backport to `dev`.
+> If you merge only to `dev`, the fix will not ship until the next release cycle."
+
+---
+
+## Step 3 — Pre-PR checklist
+
+Before the developer opens the PR, run through:
+
+1. **Branch is aligned** — suggest running `/sprint-align` if branch is `sprint/vX.X.X`
+2. **No direct commits to master or dev** — confirm work is on a proper branch
+3. **Version bump** — for `release/*` branches only: confirm `package.json` version
+   is updated before merging to master
+4. **Changelog** — `.changelog/` is gitignored and local only; do not attempt
+   `git add .changelog/`
+5. **Commit messages** — suggest `/commit-msg` if any commits on this branch
+   need to be cleaned up before the PR
+
+Report checklist status: which items pass, which need attention.
+
+---
+
+## Step 4 — PR description guidance
+
+Remind the developer:
+- PR title should follow the same conventional prefix as commits: `feat(scope): ...`
+- PR body should summarise the WHY, not just the what
+- For `release/*` → `master` PRs: include the version tag that will be applied post-merge
+- The project head reviews all PRs into master; do not merge without approval
+
+---
+
+## Hard constraints (always enforce)
+
+- **Never create, merge, or push PRs to master autonomously**
+- **Never suggest bypassing the project head's review gate**
+- **Never commit directly to `master` or `dev`** — always branch
+- If asked to "just push to master directly", refuse and explain the release trigger risk:
+  > "Every master merge fires a CI build and ships a versioned installer.
+  > Unreviewed code reaching master is a production incident, not a shortcut."

--- a/.claude/skills/new-branch.md
+++ b/.claude/skills/new-branch.md
@@ -1,0 +1,110 @@
+# New Branch Protocol
+
+Creates a correctly named, correctly based branch for any GitFlow work type.
+Invoke before starting any new unit of work.
+
+Triggered by: `/new-branch`
+
+---
+
+## Branch types, bases, and naming
+
+| Work type | Branch pattern | Base branch | Example |
+|-----------|---------------|-------------|---------|
+| New feature or experiment | `feature/<short-description>` | `dev` | `feature/voice-preview` |
+| Bug fix on live production | `fix/<short-description>` | `master` | `fix/ptt-mic-stuck` |
+| Release candidate / QA | `release/vX.X.X` | `dev` | `release/v1.2.0` |
+| Upstream redesign port | `sprint/vX.X.X` | `master` | `sprint/v1.2.0` |
+
+**Rules:**
+- `feature/*` and `release/*` always base off `dev` — never master
+- `fix/*` always base off `master` — hotfixes must ship without carrying unreleased dev work
+- `sprint/*` always base off `master` — selective port after upstream redesign
+- Descriptions use kebab-case, no version numbers in feature names
+- Keep names short and unambiguous (3–5 words max)
+
+---
+
+## Step 1 — Clarify intent
+
+Ask the developer:
+> "What are you building? (feature / hotfix / release candidate / sprint port)"
+
+If the developer describes the work without naming a type, infer from context:
+- "add X feature" → `feature/*` off `dev`
+- "fix a bug in prod" → `fix/*` off `master`
+- "start the next sprint" → `sprint/vX.X.X` off `master`
+- "prep a release" → `release/vX.X.X` off `dev`
+
+Confirm the classification before proceeding:
+> "This sounds like a `feature/*` branch. Correct?"
+
+---
+
+## Step 2 — Confirm base branch is current
+
+Run: `git fetch origin --quiet --prune`
+
+Then check the intended base is up to date locally:
+```
+git log --oneline HEAD..origin/<base-branch> | head -5
+```
+
+If the local base is behind origin, warn:
+> "Your local `[base]` is behind origin by [N] commits. Update it first:
+> `git checkout [base] && git pull --ff-only`"
+
+Do not proceed until the developer confirms the base is current.
+
+---
+
+## Step 3 — Suggest branch name
+
+Propose a name following the pattern. Use the developer's description, kebab-cased:
+
+> "Suggested branch name: `feature/voice-preview`
+> Base: `dev`
+> Command: `git checkout -b feature/voice-preview dev`"
+
+Ask: "Does this name work, or would you like to adjust it?"
+
+---
+
+## Step 4 — Output the exact command
+
+Once name and base are confirmed, output the single command to run:
+
+```
+git checkout -b <branch-name> <base-branch>
+```
+
+**Do not run this command.** Present it for the developer to execute.
+
+After the developer confirms the branch is created, suggest running `/sprint-align`
+for `sprint/*` branches, or remind them that `/merge-flow` will validate the PR
+target when they're ready to open a PR.
+
+---
+
+## Step 5 — Post-creation reminder
+
+Once the branch exists, state:
+> "Branch `[name]` created off `[base]`. When you're ready:
+> - `/commit-msg` — draft a structured commit message
+> - `/merge-flow` — confirm your PR target before opening a PR"
+
+For `sprint/*` branches specifically, add:
+> "Run `/sprint-align` now to confirm this branch is current with master."
+
+---
+
+## Hard constraints (always enforce)
+
+- **Never base a `feature/*` branch off `master`** — unreleased features
+  must not bypass the `dev` integration gate
+- **Never base a `fix/*` branch off `dev`** — hotfixes must not carry
+  unreleased dev work into production
+- **Never create branches directly on `master` or `dev`** — those branches
+  receive merges, they do not originate work
+- **Never run `git checkout -b` autonomously** — always present the command
+  and let the developer execute it

--- a/.claude/skills/sprint-align.md
+++ b/.claude/skills/sprint-align.md
@@ -1,0 +1,124 @@
+# Sprint Alignment Protocol
+
+Invoke this skill at the START of every sprint branch before writing any code.
+Triggered by: `/sprint-align`
+
+---
+
+## Step 1 — Identify branch context
+
+Run: `git rev-parse --abbrev-ref HEAD`
+
+If the branch name does not match the pattern `sprint/vX.X.X`, display a warning:
+> "Current branch does not follow the sprint/vX.X.X naming convention. Confirm this is
+> the intended sprint branch before proceeding."
+
+Ask the developer to confirm or correct before continuing.
+
+---
+
+## Step 2 — Run the alignment script
+
+Execute: `bash scripts/sprint-start.sh`
+
+Run this from the repository root. Capture the full output and exit code.
+
+If the script fails to run (bash not found, wrong working directory, permission error):
+- Report the exact error
+- Tell the developer to run manually: `bash scripts/sprint-start.sh` from the repo root
+- Do not proceed until the output is available
+
+---
+
+## Step 3 — Interpret output
+
+### Exit code 0 — ALIGNED
+
+Report to the developer:
+> "Sprint branch is aligned with master. No unmerged master commits detected.
+> Merge base: [SHA from output]. Sprint-only commits: [count]. Safe to begin work."
+
+Proceed to Step 5.
+
+### Exit code 1 — DIVERGED
+
+Summarise in natural language (do NOT paste raw script output verbatim):
+- How many commits master has that this sprint branch does not
+- The commit list from the `COMMITS ON master NOT IN SPRINT` section
+- Which files changed, from the `FILE CHANGES` section
+
+Example summary:
+> "Master has 3 commits this sprint branch does not include:
+> - abc1234 fix(ptt): mic stuck on after release
+> - def5678 feat(panel): redesign layout
+> - ghi9012 chore: update dependencies
+>
+> Affected files: src/renderer/components/OverlayApp.tsx (+12/-5),
+> src/main/index.ts (+8/-2), package.json (+1/-1)"
+
+Then proceed to Step 4.
+
+---
+
+## Step 4 — Decision prompt (DIVERGED only)
+
+Present the developer with four options:
+
+> "Master has [N] commits this sprint branch does not include.
+> How would you like to proceed?
+>
+> [R] Rebase — `git rebase master` (recommended: linear history, clean sprint base)
+> [M] Merge  — `git merge master` (preserves branch topology)
+> [S] Skip   — proceed without aligning (not recommended; state your reason)
+> [A] Abort  — I need to review the diff manually first"
+
+### If [R] or [M]:
+Provide the exact command but **do not execute it**. Wait for the developer to confirm they
+have run it, then re-run `bash scripts/sprint-start.sh` to verify alignment (Step 2).
+Do not proceed to Step 5 until exit code is 0.
+
+### If [S] (Skip):
+Record the developer's stated reason in session context. Display a persistent warning
+at the top of all subsequent responses this session:
+> "[WARN] Sprint branch skipped master alignment — [stated reason]"
+
+### If [A] (Abort):
+Suggest the developer inspect divergence manually:
+```
+git log --oneline master ^HEAD | head -20
+git diff --stat master...HEAD
+```
+Stop the skill. Await further instruction.
+
+---
+
+## Step 5 — Session context memo
+
+After alignment is confirmed (exit code 0), record in working memory:
+- Sprint branch name
+- Master HEAD SHA at time of check (`git rev-parse master`)
+- Date/time of alignment check
+
+Reference this context if the developer later asks "are we aligned with master?" without
+re-running the script.
+
+---
+
+## Hard constraints (always enforce)
+
+- **Never push to master** under any circumstances
+- **Never execute `git rebase` or `git merge` on the developer's behalf** — instruct and wait
+- **Never skip the fetch step** inside the script — stale local refs cause false ALIGNED results
+- If mid-sprint the developer asks to re-run alignment, run it again; the script handles
+  non-zero sprint-only commit counts correctly and will still report ALIGNED if master
+  hasn't moved since the last check
+
+---
+
+## GitFlow context (why this matters)
+
+Per this project's branching strategy, `sprint/vX.X.X` branches are selective ports off
+`master` after upstream redesigns. They must start from master HEAD. A diverged sprint
+branch means the project head has continued work on master that this branch was not
+rebased onto — discovered late, this causes conflict-heavy merges across already-modified
+files. This skill catches that at the session start, before the first line of code is written.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Normalize line endings
+* text=auto
+
+# Force LF for shell scripts — CRLF causes \r: command not found in bash
+*.sh text eol=lf
+
+# Force LF for markdown skill files read by Claude Code
+.claude/skills/*.md text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ release/
 .DS_Store
 Thumbs.db
 *.log
+
+# Local-only files — never commit
+CLAUDE.md
+.changelog/
+run.bat
+setup.bat

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flicky",
-  "version": "1.0.3",
+  "version": "1.2.0",
   "description": "Cross-platform AI companion — voice-driven, screen-aware assistant with a pointing cursor overlay",
   "main": "dist/main/main/index.js",
   "author": {

--- a/scripts/sprint-start.sh
+++ b/scripts/sprint-start.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# sprint-start.sh — Pre-sprint alignment check
+# Usage: bash scripts/sprint-start.sh [sprint-branch] [base-branch]
+# Defaults: current branch vs master
+set -euo pipefail
+
+SPRINT_BRANCH="${1:-$(git rev-parse --abbrev-ref HEAD)}"
+BASE_BRANCH="${2:-master}"
+
+echo "Sprint branch : $SPRINT_BRANCH"
+echo "Base branch   : $BASE_BRANCH"
+echo ""
+
+# Fetch to ensure base ref reflects remote state
+git fetch origin "$BASE_BRANCH" --quiet --prune 2>/dev/null || {
+  echo "[WARN] Could not fetch origin/$BASE_BRANCH — comparing against local ref only."
+}
+
+AHEAD_COUNT=$(git rev-list --count "$SPRINT_BRANCH".."$BASE_BRANCH")
+SPRINT_ONLY=$(git rev-list --count "$BASE_BRANCH".."$SPRINT_BRANCH")
+MERGE_BASE=$(git merge-base "$BASE_BRANCH" "$SPRINT_BRANCH")
+
+echo "=== STATUS ==="
+if [ "$AHEAD_COUNT" -eq 0 ]; then
+  echo "ALIGNED"
+  echo "Sprint branch is up to date with $BASE_BRANCH."
+  echo "Merge base    : $MERGE_BASE"
+  echo "Sprint-only commits: $SPRINT_ONLY"
+  exit 0
+else
+  echo "DIVERGED"
+  echo "$BASE_BRANCH has $AHEAD_COUNT commit(s) not present in this sprint branch."
+  echo "Sprint-only commits: $SPRINT_ONLY"
+  echo "Merge base    : $MERGE_BASE"
+  echo ""
+  echo "=== COMMITS ON $BASE_BRANCH NOT IN SPRINT ==="
+  git log --oneline "$SPRINT_BRANCH".."$BASE_BRANCH"
+  echo ""
+  echo "=== FILE CHANGES ($BASE_BRANCH vs SPRINT) ==="
+  git diff --stat "$SPRINT_BRANCH"..."$BASE_BRANCH"
+  exit 1
+fi

--- a/src/main/companion-manager.ts
+++ b/src/main/companion-manager.ts
@@ -1,6 +1,7 @@
 import { app, systemPreferences } from 'electron';
 import { ClaudeAPI } from './services/claude-api';
 import { OpenAIAPI } from './services/openai-api';
+import { OllamaAPI } from './services/ollama-api';
 import { ElevenLabsTTS } from './services/elevenlabs-tts';
 import { createTranscriptionProvider, type TranscriptionProvider } from './services/transcription';
 import { captureAllDisplays } from './services/screen-capture';
@@ -50,6 +51,7 @@ export class CompanionManager {
 
   private claude: ClaudeAPI;
   private openai: OpenAIAPI;
+  private ollama: OllamaAPI;
   private tts: ElevenLabsTTS;
   private context: ContextManager;
   private transcriptionProvider: TranscriptionProvider | null = null;
@@ -77,6 +79,7 @@ export class CompanionManager {
     this.callbacks = callbacks;
     this.claude = new ClaudeAPI();
     this.openai = new OpenAIAPI();
+    this.ollama = new OllamaAPI();
     this.tts = new ElevenLabsTTS();
     this.context = new ContextManager();
 
@@ -479,6 +482,34 @@ export class CompanionManager {
         settings.selectedOpenAIModel,
         mindOptions,
         mindCallbacks,
+      );
+    } else if (settings.mindProvider === 'ollama') {
+      const connections = (settings.localConnections ?? []).filter((c) => c.enabled);
+      const conn = connections[0];
+      if (!conn) {
+        mindCallbacks.onError(new Error('No enabled local connection. Add one in Mind → Local.'));
+        return;
+      }
+      const bearerToken = keyStore.getApiKey(`local_${conn.id}`) ?? undefined;
+      let model: string;
+      if (conn.activeModelId) {
+        model = conn.activeModelId;
+      } else if (conn.modelIds.length > 0) {
+        model = conn.modelIds[0];
+      } else {
+        const discovered = await this.ollama.getModels(conn.url, bearerToken);
+        model = discovered[0] ?? 'llama3';
+      }
+      const fullModelId = conn.prefixId ? `${conn.prefixId}${model}` : model;
+      await this.ollama.streamChat(
+        result.text,
+        this.lastScreenshots,
+        this.context.getMessagesForSend(),
+        fullModelId,
+        { replyTone: mindOptions.replyTone, signal: mindOptions.signal },
+        mindCallbacks,
+        conn.url,
+        bearerToken,
       );
     } else {
       await this.claude.streamChat(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,9 +2,13 @@ import { app, BrowserWindow, Tray, Menu, globalShortcut, screen, ipcMain, shell,
 import path from 'path';
 import { CompanionManager } from './companion-manager';
 import { createPanelWindow, createOverlayWindow, createStreamWindow } from './windows';
-import { IPC, type StreamVisibility, type StreamWindowBounds } from '../shared/types';
+import { IPC, type StreamVisibility, type StreamWindowBounds, type LocalConnection } from '../shared/types';
 import { AUDIO_IPC } from './services/audio-capture';
 import * as chatHistory from './services/chat-history-store';
+import * as settingsStore from './services/settings-store';
+import { setApiKey, getApiKey, deleteApiKey } from './services/key-store';
+import { OllamaAPI } from './services/ollama-api';
+import { randomUUID } from 'crypto';
 
 // Prevent multiple instances
 const gotLock = app.requestSingleInstanceLock();
@@ -280,6 +284,82 @@ app.whenReady().then(() => {
   ipcMain.on(IPC.SET_API_KEY, (_e, name, value) => companion.setApiKey(name, value));
   ipcMain.on(IPC.DELETE_API_KEY, (_e, name) => companion.deleteApiKey(name));
   ipcMain.handle(IPC.GET_API_KEY_STATUS, () => companion.getApiKeyStatus());
+
+  // Local Connection Management
+  const ollamaAPI = new OllamaAPI();
+
+  function emitLocalConnections(): void {
+    const settings = companion.getSettings();
+    sendToPanel(IPC.SETTINGS_CHANGED, settings);
+  }
+
+  ipcMain.handle(IPC.GET_LOCAL_CONNECTIONS, () => {
+    return settingsStore.get('localConnections') ?? [];
+  });
+
+  ipcMain.handle(IPC.ADD_LOCAL_CONNECTION, (_e, conn: Omit<LocalConnection, 'id'>) => {
+    const connections = settingsStore.get('localConnections') ?? [];
+    const newConn: LocalConnection = { ...conn, id: randomUUID() };
+    settingsStore.set('localConnections', [...connections, newConn]);
+    emitLocalConnections();
+    return newConn;
+  });
+
+  ipcMain.handle(IPC.UPDATE_LOCAL_CONNECTION, (_e, id: string, patch: Partial<LocalConnection>) => {
+    const connections = settingsStore.get('localConnections') ?? [];
+    const updated = connections.map((c) => (c.id === id ? { ...c, ...patch, id } : c));
+    settingsStore.set('localConnections', updated);
+    emitLocalConnections();
+  });
+
+  ipcMain.handle(IPC.DELETE_LOCAL_CONNECTION, (_e, id: string) => {
+    const connections = settingsStore.get('localConnections') ?? [];
+    settingsStore.set('localConnections', connections.filter((c) => c.id !== id));
+    try { deleteApiKey(`local_${id}`); } catch { /* key may not exist */ }
+    emitLocalConnections();
+  });
+
+  ipcMain.handle(IPC.TEST_LOCAL_CONNECTION, (_e, url: string, bearerToken?: string) => {
+    return ollamaAPI.testConnection(url, bearerToken);
+  });
+
+  ipcMain.handle(IPC.SET_LOCAL_CONNECTION_KEY, (_e, id: string, token: string) => {
+    setApiKey(`local_${id}`, token);
+  });
+
+  ipcMain.handle(IPC.DELETE_LOCAL_CONNECTION_KEY, (_e, id: string) => {
+    try { deleteApiKey(`local_${id}`); } catch { /* key may not exist */ }
+  });
+
+  // Ollama Model Management
+  ipcMain.handle(IPC.GET_OLLAMA_MODELS, (_e, url: string, bearerToken?: string) => {
+    return ollamaAPI.getModelDetails(url, bearerToken);
+  });
+
+  ipcMain.on(IPC.PULL_OLLAMA_MODEL, (event, url: string, modelTag: string, bearerToken?: string) => {
+    const controller = new AbortController();
+    ollamaAPI.pullModel(
+      url,
+      modelTag,
+      bearerToken,
+      (progress) => { event.sender.send(IPC.OLLAMA_PULL_PROGRESS, progress); },
+      controller.signal,
+    ).then(() => {
+      event.sender.send(IPC.OLLAMA_PULL_COMPLETE, { model: modelTag });
+    }).catch((err: Error) => {
+      if (err.name !== 'AbortError') {
+        event.sender.send(IPC.OLLAMA_PULL_ERROR, { error: err.message });
+      }
+    });
+  });
+
+  ipcMain.handle(IPC.DELETE_OLLAMA_MODEL, (_e, url: string, modelName: string, bearerToken?: string) => {
+    return ollamaAPI.deleteModel(url, modelName, bearerToken);
+  });
+
+  ipcMain.handle(IPC.CREATE_OLLAMA_MODEL, (_e, url: string, modelTag: string, modelfileJson: string, bearerToken?: string) => {
+    return ollamaAPI.createModel(url, modelTag, modelfileJson, bearerToken);
+  });
 
   // Audio capture: relay chunks from overlay renderer to companion
   ipcMain.on(AUDIO_IPC.AUDIO_CHUNK, (_e, buffer: Buffer) => {

--- a/src/main/services/key-store.ts
+++ b/src/main/services/key-store.ts
@@ -18,7 +18,8 @@ import { writeFileAtomic } from './fs-util';
  */
 
 const KEY_NAMES = ['anthropic', 'openai', 'elevenlabs', 'groq'] as const;
-export type ApiKeyName = (typeof KEY_NAMES)[number];
+export type NamedApiKey = (typeof KEY_NAMES)[number];
+export type ApiKeyName = NamedApiKey | string;
 
 interface KeyFile {
   encryptedKeys: Record<string, string>; // base64-encoded ciphertext
@@ -83,7 +84,7 @@ export function deleteApiKey(name: ApiKeyName): void {
   writeKeyFile(data);
 }
 
-export function getKeyStatus(): Record<ApiKeyName, boolean> {
+export function getKeyStatus(): Record<NamedApiKey, boolean> {
   return {
     anthropic: hasApiKey('anthropic'),
     openai: hasApiKey('openai'),

--- a/src/main/services/ollama-api.ts
+++ b/src/main/services/ollama-api.ts
@@ -1,0 +1,356 @@
+import type {
+  ConversationTurn,
+  ScreenCapture,
+  ReplyTone,
+  OllamaModelInfo,
+  OllamaPullProgress,
+} from '../../shared/types';
+import { buildSystemPrompt } from './prompts';
+
+const CONNECTION_TIMEOUT_MS = 3_000;
+
+// Model families that support vision/multimodal input.
+const VISION_FAMILIES = [
+  'llava', 'bakllava', 'moondream', 'cogvlm', 'minicpm-v',
+  'llava-llama3', 'llava-phi3', 'granite3.2-vision',
+  'qwen2-vl', 'qwen2.5-vl', 'qwen3-vl',
+  'llava-v1.6', 'llava-v1.5',
+  'gemma3', 'gemma4', 'mistral-small3.1', 'devstral',
+];
+
+export function isVisionModel(modelName: string): boolean {
+  const lower = modelName.toLowerCase();
+  return VISION_FAMILIES.some((f) => lower.includes(f));
+}
+
+export interface OllamaStreamCallbacks {
+  onChunk: (text: string) => void;
+  onComplete: (fullText: string, usage?: { inputTokens: number; outputTokens: number }) => void;
+  onError: (error: Error) => void;
+}
+
+export interface OllamaChatOptions {
+  replyTone: ReplyTone;
+  signal?: AbortSignal;
+}
+
+export interface OllamaTestResult {
+  ok: boolean;
+  latencyMs: number;
+  modelCount?: number;
+  error?: string;
+}
+
+function authHeaders(bearerToken?: string): Record<string, string> {
+  if (bearerToken) return { Authorization: `Bearer ${bearerToken}` };
+  return {};
+}
+
+// Strip trailing /v1 so callers can safely append /v1/... without doubling.
+// e.g. https://api.x.ai/v1 → https://api.x.ai
+//      http://localhost:11434 → http://localhost:11434
+function normalizeBase(url: string): string {
+  return url.replace(/\/v1\/?$/, '').replace(/\/$/, '');
+}
+
+async function timedFetch(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const signal = init.signal
+    ? AbortSignal.any([init.signal as AbortSignal, controller.signal])
+    : controller.signal;
+  try {
+    const res = await fetch(url, { ...init, signal });
+    clearTimeout(timer);
+    return res;
+  } catch (err) {
+    clearTimeout(timer);
+    throw err;
+  }
+}
+
+export class OllamaAPI {
+  // ── Connection health ───────────────────────────────────────────────
+
+  async testConnection(url: string, bearerToken?: string): Promise<OllamaTestResult> {
+    const base = normalizeBase(url);
+    const start = Date.now();
+    try {
+      // Try Ollama-native endpoint first; fall back to OpenAI-compat for external providers.
+      let response = await timedFetch(
+        `${base}/api/tags`,
+        { headers: authHeaders(bearerToken) },
+        CONNECTION_TIMEOUT_MS,
+      );
+      if (response.status === 404) {
+        response = await timedFetch(
+          `${base}/v1/models`,
+          { headers: authHeaders(bearerToken) },
+          CONNECTION_TIMEOUT_MS,
+        );
+      }
+      const latencyMs = Date.now() - start;
+      if (!response.ok) return { ok: false, latencyMs, error: `HTTP ${response.status}` };
+      const data = await response.json() as {
+        models?: OllamaModelInfo[];
+        data?: { id: string }[];
+      };
+      const modelCount = data.models?.length ?? data.data?.length ?? 0;
+      return { ok: true, latencyMs, modelCount };
+    } catch (err) {
+      const latencyMs = Date.now() - start;
+      const msg = err instanceof Error ? err.message : String(err);
+      return { ok: false, latencyMs, error: msg.includes('abort') ? 'Connection timed out' : msg };
+    }
+  }
+
+  // ── Model listing ───────────────────────────────────────────────────
+
+  async getModels(url: string, bearerToken?: string): Promise<string[]> {
+    const base = normalizeBase(url);
+    try {
+      let response = await timedFetch(
+        `${base}/api/tags`,
+        { headers: authHeaders(bearerToken) },
+        CONNECTION_TIMEOUT_MS,
+      );
+      if (response.status === 404) {
+        response = await timedFetch(
+          `${base}/v1/models`,
+          { headers: authHeaders(bearerToken) },
+          CONNECTION_TIMEOUT_MS,
+        );
+        if (!response.ok) return [];
+        const data = await response.json() as { data?: { id: string }[] };
+        return (data.data ?? []).map((m) => m.id);
+      }
+      if (!response.ok) return [];
+      const data = await response.json() as { models?: OllamaModelInfo[] };
+      return (data.models ?? []).map((m) => m.name);
+    } catch {
+      return [];
+    }
+  }
+
+  async getModelDetails(url: string, bearerToken?: string): Promise<OllamaModelInfo[]> {
+    const base = normalizeBase(url);
+    try {
+      let response = await timedFetch(
+        `${base}/api/tags`,
+        { headers: authHeaders(bearerToken) },
+        CONNECTION_TIMEOUT_MS,
+      );
+      if (response.status === 404) {
+        response = await timedFetch(
+          `${base}/v1/models`,
+          { headers: authHeaders(bearerToken) },
+          CONNECTION_TIMEOUT_MS,
+        );
+        if (!response.ok) return [];
+        const data = await response.json() as { data?: { id: string }[] };
+        return (data.data ?? []).map((m) => ({ name: m.id }));
+      }
+      if (!response.ok) return [];
+      const data = await response.json() as { models?: OllamaModelInfo[] };
+      return data.models ?? [];
+    } catch {
+      return [];
+    }
+  }
+
+  // ── Model pull (streaming NDJSON) ───────────────────────────────────
+
+  async pullModel(
+    url: string,
+    modelTag: string,
+    bearerToken: string | undefined,
+    onProgress: (p: OllamaPullProgress) => void,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const response = await fetch(`${url}/api/pull`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(bearerToken) },
+      body: JSON.stringify({ name: modelTag, stream: true }),
+      signal,
+    });
+    if (!response.ok) {
+      const errText = await response.text();
+      throw new Error(`Pull failed ${response.status}: ${errText}`);
+    }
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('No response body');
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const event = JSON.parse(trimmed) as OllamaPullProgress;
+          onProgress(event);
+        } catch { /* skip malformed */ }
+      }
+    }
+  }
+
+  // ── Model delete ────────────────────────────────────────────────────
+
+  async deleteModel(url: string, modelName: string, bearerToken?: string): Promise<void> {
+    const response = await timedFetch(
+      `${url}/api/delete`,
+      {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json', ...authHeaders(bearerToken) },
+        body: JSON.stringify({ name: modelName }),
+      },
+      CONNECTION_TIMEOUT_MS,
+    );
+    if (!response.ok) {
+      const errText = await response.text();
+      throw new Error(`Delete failed ${response.status}: ${errText}`);
+    }
+  }
+
+  // ── Model create (from modelfile JSON) ──────────────────────────────
+
+  async createModel(
+    url: string,
+    modelTag: string,
+    modelfileJson: string,
+    bearerToken?: string,
+  ): Promise<void> {
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(modelfileJson) as Record<string, unknown>;
+      body.model = modelTag;
+    } catch {
+      throw new Error('Invalid JSON in modelfile field.');
+    }
+    const response = await timedFetch(
+      `${url}/api/create`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders(bearerToken) },
+        body: JSON.stringify(body),
+      },
+      30_000,
+    );
+    if (!response.ok) {
+      const errText = await response.text();
+      throw new Error(`Create failed ${response.status}: ${errText}`);
+    }
+  }
+
+  // ── Chat (inference) ────────────────────────────────────────────────
+
+  async streamChat(
+    prompt: string,
+    screenshots: ScreenCapture[],
+    history: ConversationTurn[],
+    model: string,
+    options: OllamaChatOptions,
+    callbacks: OllamaStreamCallbacks,
+    baseUrl: string,
+    bearerToken?: string,
+  ): Promise<void> {
+    const systemPrompt = buildSystemPrompt(options.replyTone, { hasWebSearch: false });
+    const vision = isVisionModel(model);
+
+    const messages: Array<{ role: string; content: unknown }> = [
+      { role: 'system', content: systemPrompt },
+    ];
+
+    for (const turn of history) {
+      messages.push({ role: turn.role, content: turn.content });
+    }
+
+    // Only send image content for vision-capable models.
+    if (vision && screenshots.length > 0) {
+      const userContent: Array<Record<string, unknown>> = [];
+      for (let i = 0; i < screenshots.length; i++) {
+        const sc = screenshots[i];
+        userContent.push({
+          type: 'text',
+          text: `[screen${i}] ${sc.imageWidth}x${sc.imageHeight}px.${sc.isCursorScreen ? ' (active screen)' : ''}`,
+        });
+        userContent.push({
+          type: 'image_url',
+          image_url: { url: `data:image/jpeg;base64,${sc.dataBase64}` },
+        });
+      }
+      userContent.push({ type: 'text', text: prompt });
+      messages.push({ role: 'user', content: userContent });
+    } else {
+      messages.push({ role: 'user', content: prompt });
+    }
+
+    const body = {
+      model,
+      messages,
+      stream: true,
+      stream_options: { include_usage: true },
+    };
+
+    try {
+      const response = await fetch(`${normalizeBase(baseUrl)}/v1/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders(bearerToken) },
+        body: JSON.stringify(body),
+        signal: options.signal,
+      });
+
+      if (!response.ok) {
+        const errText = await response.text();
+        throw new Error(`Ollama error ${response.status}: ${errText}`);
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) throw new Error('No response body');
+
+      const decoder = new TextDecoder();
+      let fullText = '';
+      let buffer = '';
+      let inputTokens = 0;
+      let outputTokens = 0;
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.slice(6);
+          if (data === '[DONE]') continue;
+          try {
+            const event = JSON.parse(data);
+            const chunk = event.choices?.[0]?.delta?.content;
+            if (typeof chunk === 'string' && chunk.length > 0) {
+              fullText += chunk;
+              callbacks.onChunk(chunk);
+            }
+            if (event.usage) {
+              inputTokens = event.usage.prompt_tokens ?? 0;
+              outputTokens = event.usage.completion_tokens ?? 0;
+            }
+          } catch { /* skip malformed SSE lines */ }
+        }
+      }
+
+      callbacks.onComplete(fullText, { inputTokens, outputTokens });
+    } catch (err) {
+      if (err instanceof Error && (err.name === 'AbortError' || options.signal?.aborted)) return;
+      callbacks.onError(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+}

--- a/src/main/services/settings-store.ts
+++ b/src/main/services/settings-store.ts
@@ -12,6 +12,7 @@ import type {
   ReplyTone,
   StreamVisibility,
   StreamWindowBounds,
+  LocalConnection,
 } from '../../shared/types';
 
 /**
@@ -40,6 +41,8 @@ export interface StoredSettings {
   streamVisibility: StreamVisibility;
   streamWindowBounds: StreamWindowBounds | null;
 
+  localConnections: LocalConnection[];
+
   onboardingComplete: boolean;
 }
 
@@ -63,6 +66,8 @@ const DEFAULTS: StoredSettings = {
   pushToTalkShortcut: 'Ctrl+Alt+X',
   streamVisibility: 'off',
   streamWindowBounds: null,
+
+  localConnections: [],
 
   onboardingComplete: false,
 };

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -16,7 +16,11 @@ import type {
   ChatEntry,
   StreamVisibility,
   StreamWindowBounds,
+  LocalConnection,
+  OllamaModelInfo,
+  OllamaPullProgress,
 } from '../shared/types';
+import type { OllamaTestResult } from '../main/services/ollama-api';
 
 const api = {
   // ── Settings ───────────────────────────────────────────────────────
@@ -67,6 +71,47 @@ const api = {
   // ── Chat history ────────────────────────────────────────────────────
   getChatHistory: (): Promise<ChatEntry[]> => ipcRenderer.invoke(IPC.GET_CHAT_HISTORY),
   clearChatHistory: (): void => ipcRenderer.send(IPC.CLEAR_CHAT_HISTORY),
+
+  // ── Local Connections ─────────────────────────────────────────────────
+  getLocalConnections: (): Promise<LocalConnection[]> =>
+    ipcRenderer.invoke(IPC.GET_LOCAL_CONNECTIONS),
+  addLocalConnection: (conn: Omit<LocalConnection, 'id'>): Promise<LocalConnection> =>
+    ipcRenderer.invoke(IPC.ADD_LOCAL_CONNECTION, conn),
+  updateLocalConnection: (id: string, patch: Partial<LocalConnection>): Promise<void> =>
+    ipcRenderer.invoke(IPC.UPDATE_LOCAL_CONNECTION, id, patch),
+  deleteLocalConnection: (id: string): Promise<void> =>
+    ipcRenderer.invoke(IPC.DELETE_LOCAL_CONNECTION, id),
+  testLocalConnection: (url: string, bearerToken?: string): Promise<OllamaTestResult> =>
+    ipcRenderer.invoke(IPC.TEST_LOCAL_CONNECTION, url, bearerToken),
+  getOllamaModels: (url: string, bearerToken?: string): Promise<OllamaModelInfo[]> =>
+    ipcRenderer.invoke(IPC.GET_OLLAMA_MODELS, url, bearerToken),
+  setLocalConnectionKey: (id: string, token: string): Promise<void> =>
+    ipcRenderer.invoke(IPC.SET_LOCAL_CONNECTION_KEY, id, token),
+  deleteLocalConnectionKey: (id: string): Promise<void> =>
+    ipcRenderer.invoke(IPC.DELETE_LOCAL_CONNECTION_KEY, id),
+
+  // ── Ollama Model Management ───────────────────────────────────────────
+  pullOllamaModel: (url: string, modelTag: string, bearerToken?: string): void =>
+    ipcRenderer.send(IPC.PULL_OLLAMA_MODEL, url, modelTag, bearerToken),
+  onOllamaPullProgress: (cb: (p: OllamaPullProgress) => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, p: OllamaPullProgress) => cb(p);
+    ipcRenderer.on(IPC.OLLAMA_PULL_PROGRESS, handler);
+    return () => ipcRenderer.removeListener(IPC.OLLAMA_PULL_PROGRESS, handler);
+  },
+  onOllamaPullComplete: (cb: (info: { model: string }) => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, info: { model: string }) => cb(info);
+    ipcRenderer.on(IPC.OLLAMA_PULL_COMPLETE, handler);
+    return () => ipcRenderer.removeListener(IPC.OLLAMA_PULL_COMPLETE, handler);
+  },
+  onOllamaPullError: (cb: (info: { error: string }) => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, info: { error: string }) => cb(info);
+    ipcRenderer.on(IPC.OLLAMA_PULL_ERROR, handler);
+    return () => ipcRenderer.removeListener(IPC.OLLAMA_PULL_ERROR, handler);
+  },
+  deleteOllamaModel: (url: string, modelName: string, bearerToken?: string): Promise<void> =>
+    ipcRenderer.invoke(IPC.DELETE_OLLAMA_MODEL, url, modelName, bearerToken),
+  createOllamaModel: (url: string, modelTag: string, modelfileJson: string, bearerToken?: string): Promise<void> =>
+    ipcRenderer.invoke(IPC.CREATE_OLLAMA_MODEL, url, modelTag, modelfileJson, bearerToken),
 
   // ── Lifecycle ──────────────────────────────────────────────────────
   openExternal: (url: string): void => ipcRenderer.send(IPC.OPEN_EXTERNAL, url),

--- a/src/renderer/components/panel/AddConnectionModal.tsx
+++ b/src/renderer/components/panel/AddConnectionModal.tsx
@@ -1,0 +1,272 @@
+import { useState, useEffect } from 'react';
+import type { LocalConnection } from '../../../shared/types';
+import type { OllamaTestResult } from '../../../main/services/ollama-api';
+
+interface AddConnectionModalProps {
+  existing?: LocalConnection;
+  onSave: (conn: LocalConnection) => void;
+  onClose: () => void;
+  onDelete?: (conn: LocalConnection) => void;
+}
+
+type VerifyState = 'idle' | 'pending' | 'ok' | 'error';
+
+export function AddConnectionModal({ existing, onSave, onClose, onDelete }: AddConnectionModalProps) {
+  const [connType, setConnType] = useState<'local' | 'external'>(existing?.type ?? 'local');
+  const [url, setUrl] = useState(existing?.url ?? '');
+  const [bearerEnabled, setBearerEnabled] = useState(existing?.bearerEnabled ?? false);
+  const [bearerToken, setBearerToken] = useState('');
+  const [bearerVisible, setBearerVisible] = useState(false);
+  const [prefixId, setPrefixId] = useState(existing?.prefixId ?? '');
+  const [modelInput, setModelInput] = useState('');
+  const [modelIds, setModelIds] = useState<string[]>(existing?.modelIds ?? []);
+  const [tagInput, setTagInput] = useState('');
+  const [tags, setTags] = useState<string[]>(existing?.tags ?? []);
+  const [verifyState, setVerifyState] = useState<VerifyState>('idle');
+  const [verifyResult, setVerifyResult] = useState<OllamaTestResult | null>(null);
+
+  // Pre-fill default URL for local type
+  useEffect(() => {
+    if (!existing && connType === 'local' && !url) {
+      setUrl('http://localhost:11434');
+    }
+  }, [connType]);
+
+  const handleVerify = async () => {
+    if (!url.trim()) return;
+    setVerifyState('pending');
+    setVerifyResult(null);
+    try {
+      const token = bearerEnabled && bearerToken.trim() ? bearerToken.trim() : undefined;
+      const result = await window.flicky.testLocalConnection(url.trim(), token);
+      setVerifyResult(result);
+      setVerifyState(result.ok ? 'ok' : 'error');
+    } catch {
+      setVerifyState('error');
+      setVerifyResult({ ok: false, latencyMs: 0, error: 'Unexpected error' });
+    }
+  };
+
+  const addModelId = () => {
+    const v = modelInput.trim();
+    if (v && !modelIds.includes(v)) setModelIds((prev) => [...prev, v]);
+    setModelInput('');
+  };
+
+  const removeModelId = (id: string) => setModelIds((prev) => prev.filter((m) => m !== id));
+
+  const addTag = () => {
+    const v = tagInput.trim();
+    if (v && !tags.includes(v)) setTags((prev) => [...prev, v]);
+    setTagInput('');
+  };
+
+  const removeTag = (t: string) => setTags((prev) => prev.filter((x) => x !== t));
+
+  const handleSave = async () => {
+    const trimmedUrl = url.trim();
+    if (!trimmedUrl) return;
+
+    const conn: LocalConnection = {
+      id: existing?.id ?? '',
+      type: connType,
+      url: trimmedUrl,
+      enabled: existing?.enabled ?? true,
+      bearerEnabled,
+      prefixId: prefixId.trim() || undefined,
+      modelIds,
+      tags,
+    };
+
+    if (existing?.id) {
+      await window.flicky.updateLocalConnection(existing.id, conn);
+      if (bearerEnabled && bearerToken.trim()) {
+        await window.flicky.setLocalConnectionKey(existing.id, bearerToken.trim());
+      } else if (!bearerEnabled) {
+        await window.flicky.deleteLocalConnectionKey(existing.id);
+      }
+      onSave({ ...conn, id: existing.id });
+    } else {
+      const saved = await window.flicky.addLocalConnection(conn);
+      if (bearerEnabled && bearerToken.trim()) {
+        await window.flicky.setLocalConnectionKey(saved.id, bearerToken.trim());
+      }
+      onSave(saved);
+    }
+  };
+
+  const canSave = url.trim().length > 0;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-box" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <span>{existing ? 'Edit Connection' : 'Add Connection'}</span>
+          <button className="modal-close" onClick={onClose}>✕</button>
+        </div>
+
+        {/* Connection Type */}
+        <div className="modal-field">
+          <div className="modal-label">Connection Type</div>
+          <div className="seg">
+            <button
+              className={connType === 'local' ? 'on' : ''}
+              onClick={() => setConnType('local')}
+            >
+              Local
+            </button>
+            <button
+              className={connType === 'external' ? 'on' : ''}
+              onClick={() => setConnType('external')}
+            >
+              External
+            </button>
+          </div>
+        </div>
+
+        {/* URL */}
+        <div className="modal-field">
+          <div className="modal-label">URL</div>
+          <div className="modal-input-row">
+            <input
+              type="text"
+              className="modal-input"
+              placeholder="http://localhost:11434"
+              value={url}
+              onChange={(e) => { setUrl(e.target.value); setVerifyState('idle'); }}
+            />
+            <button
+              className={`btn xs ${verifyState === 'ok' ? 'primary' : ''}`}
+              onClick={handleVerify}
+              disabled={verifyState === 'pending' || !url.trim()}
+            >
+              {verifyState === 'pending' ? '…' : verifyState === 'ok' ? '✓ Live' : 'Verify'}
+            </button>
+          </div>
+          {verifyResult && (
+            <div className={`modal-hint ${verifyResult.ok ? 'ok' : 'err'}`}>
+              {verifyResult.ok
+                ? `Connected · ${verifyResult.latencyMs}ms${verifyResult.modelCount !== undefined ? ` · ${verifyResult.modelCount} model${verifyResult.modelCount !== 1 ? 's' : ''} available` : ''}`
+                : `Failed: ${verifyResult.error ?? 'unknown error'}`}
+            </div>
+          )}
+        </div>
+
+        {/* Auth */}
+        <div className="modal-field">
+          <div className="modal-label">Auth</div>
+          <div className="modal-auth-row">
+            <div className="seg" style={{ flexShrink: 0 }}>
+              <button className={!bearerEnabled ? 'on' : ''} onClick={() => setBearerEnabled(false)}>
+                None
+              </button>
+              <button className={bearerEnabled ? 'on' : ''} onClick={() => setBearerEnabled(true)}>
+                Bearer
+              </button>
+            </div>
+            {bearerEnabled && (
+              <>
+                <input
+                  type={bearerVisible ? 'text' : 'password'}
+                  className="modal-input"
+                  placeholder={existing?.bearerEnabled ? '(unchanged)' : 'API key or token'}
+                  value={bearerToken}
+                  onChange={(e) => setBearerToken(e.target.value)}
+                />
+                <button
+                  className="btn xs subtle"
+                  onClick={() => setBearerVisible((v) => !v)}
+                  title={bearerVisible ? 'Hide' : 'Show'}
+                >
+                  {bearerVisible ? '🙈' : '👁'}
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Prefix ID */}
+        <div className="modal-field">
+          <div className="modal-label">Prefix ID</div>
+          <input
+            type="text"
+            className="modal-input"
+            placeholder="e.g. ollama/"
+            value={prefixId}
+            onChange={(e) => setPrefixId(e.target.value)}
+          />
+          <div className="modal-hint">Prepended to model names at inference time.</div>
+        </div>
+
+        {/* Model IDs */}
+        <div className="modal-field">
+          <div className="modal-label">Model IDs</div>
+          <div className="modal-hint" style={{ marginBottom: 6 }}>
+            Leave empty to include all models from the <code>/api/tags</code> endpoint.
+          </div>
+          {modelIds.length > 0 && (
+            <div className="tag-list">
+              {modelIds.map((m) => (
+                <span key={m} className="tag-chip">
+                  {m}
+                  <button onClick={() => removeModelId(m)}>✕</button>
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="modal-input-row">
+            <input
+              type="text"
+              className="modal-input"
+              placeholder="e.g. llama3:8b"
+              value={modelInput}
+              onChange={(e) => setModelInput(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') addModelId(); }}
+            />
+            <button className="btn xs" onClick={addModelId} disabled={!modelInput.trim()}>+</button>
+          </div>
+        </div>
+
+        {/* Tags */}
+        <div className="modal-field">
+          <div className="modal-label">Tags</div>
+          {tags.length > 0 && (
+            <div className="tag-list">
+              {tags.map((t) => (
+                <span key={t} className="tag-chip">
+                  {t}
+                  <button onClick={() => removeTag(t)}>✕</button>
+                </span>
+              ))}
+            </div>
+          )}
+          <input
+            type="text"
+            className="modal-input"
+            placeholder="Add a tag…"
+            value={tagInput}
+            onChange={(e) => setTagInput(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') addTag(); }}
+          />
+        </div>
+
+        <div className="modal-footer">
+          {existing && onDelete && (
+            <button
+              className="btn xs danger"
+              onClick={() => onDelete(existing)}
+            >
+              Delete
+            </button>
+          )}
+          <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+            <button className="btn xs subtle" onClick={onClose}>Cancel</button>
+            <button className="btn xs primary" onClick={handleSave} disabled={!canSave}>
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/panel/ConnectionRow.tsx
+++ b/src/renderer/components/panel/ConnectionRow.tsx
@@ -1,0 +1,37 @@
+import type { LocalConnection } from '../../../shared/types';
+
+interface ConnectionRowProps {
+  conn: LocalConnection;
+  onManage: (conn: LocalConnection) => void;
+  onConfigure: (conn: LocalConnection) => void;
+  onToggle: (conn: LocalConnection) => void;
+}
+
+export function ConnectionRow({ conn, onManage, onConfigure, onToggle }: ConnectionRowProps) {
+  const displayUrl = conn.label ?? conn.url;
+  const activeModel = conn.activeModelId;
+
+  return (
+    <div className={`conn-row ${conn.enabled ? '' : 'disabled'}`}>
+      <div className="conn-info">
+        <div className="conn-url" title={conn.url}>{displayUrl}</div>
+        {activeModel && (
+          <div className="conn-model">{activeModel}</div>
+        )}
+      </div>
+      <div className="conn-actions">
+        <button className="btn xs subtle" onClick={() => onManage(conn)}>
+          Manage
+        </button>
+        <button className="btn xs subtle" onClick={() => onConfigure(conn)}>
+          Configure
+        </button>
+        <button
+          className={`toggle-pill ${conn.enabled ? 'on' : ''}`}
+          onClick={() => onToggle(conn)}
+          title={conn.enabled ? 'Disable' : 'Enable'}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/panel/MindTab.tsx
+++ b/src/renderer/components/panel/MindTab.tsx
@@ -8,6 +8,7 @@ import type {
   ReplyTone,
 } from '../../../shared/types';
 import { ProviderKey } from './ProviderKey';
+import { OllamaSection } from './OllamaSection';
 
 interface MindTabProps {
   settings: FlickySettings;
@@ -56,9 +57,16 @@ const OPENAI_MODELS: Array<ModelEntry<OpenAIModel>> = [
 export function MindTab({ settings }: MindTabProps) {
   const [providerOpen, setProviderOpen] = useState(false);
 
-  const isAnthropic = settings.mindProvider === 'anthropic';
+  const provider = settings.mindProvider;
+  const isAnthropic = provider === 'anthropic';
+  const isOpenAI = provider === 'openai';
+  const isOllama = provider === 'ollama';
   const setTone = (t: ReplyTone) => window.flicky.setReplyTone(t);
   const setDepth = (d: ReasoningDepth) => window.flicky.setReasoningDepth(d);
+
+  const providerLabel = isAnthropic ? 'Anthropic' : isOpenAI ? 'OpenAI' : 'Local';
+  const providerLogoText = isAnthropic ? 'A' : isOpenAI ? 'Ai' : '⬡';
+  const providerLogoClass = isAnthropic ? '' : isOpenAI ? 'openai' : 'local';
 
   return (
     <>
@@ -79,40 +87,37 @@ export function MindTab({ settings }: MindTabProps) {
             className="provider-pick"
             onClick={() => setProviderOpen((x) => !x)}
           >
-            <div className={`provider-logo ${isAnthropic ? '' : 'openai'}`}>
-              {isAnthropic ? 'A' : 'Ai'}
-            </div>
-            <span>{isAnthropic ? 'Anthropic' : 'OpenAI'}</span>
+            <div className={`provider-logo ${providerLogoClass}`}>{providerLogoText}</div>
+            <span>{providerLabel}</span>
             <span className="chev">▾</span>
           </button>
         </div>
 
         {providerOpen && (
           <div className="voice-list" style={{ marginTop: 8 }}>
-            <button
-              className={`voice-item ${isAnthropic ? 'on' : ''}`}
-              onClick={() => {
-                window.flicky.setMindProvider('anthropic');
-                setProviderOpen(false);
-              }}
-            >
-              <div className="nm">Anthropic</div>
-              <div className="sub">Claude Sonnet / Opus · built-in web search</div>
-            </button>
-            <button
-              className={`voice-item ${!isAnthropic ? 'on' : ''}`}
-              onClick={() => {
-                window.flicky.setMindProvider('openai');
-                setProviderOpen(false);
-              }}
-            >
-              <div className="nm">OpenAI</div>
-              <div className="sub">GPT-5 · GPT-4o · reasoning effort</div>
-            </button>
+            {(
+              [
+                { id: 'anthropic', label: 'Anthropic', sub: 'Claude Sonnet / Opus · built-in web search' },
+                { id: 'openai', label: 'OpenAI', sub: 'GPT-5 · GPT-4o · reasoning effort' },
+                { id: 'ollama', label: 'Local', sub: 'Ollama · LM Studio · vLLM · any OpenAI-compatible endpoint' },
+              ] as Array<{ id: MindProvider; label: string; sub: string }>
+            ).map((p) => (
+              <button
+                key={p.id}
+                className={`voice-item ${provider === p.id ? 'on' : ''}`}
+                onClick={() => {
+                  window.flicky.setMindProvider(p.id);
+                  setProviderOpen(false);
+                }}
+              >
+                <div className="nm">{p.label}</div>
+                <div className="sub">{p.sub}</div>
+              </button>
+            ))}
           </div>
         )}
 
-        {isAnthropic ? (
+        {isAnthropic && (
           <ProviderKey
             name="anthropic"
             providerLabel="Anthropic"
@@ -121,7 +126,8 @@ export function MindTab({ settings }: MindTabProps) {
             keyPlaceholder="sk-ant-..."
             hideProviderHeader
           />
-        ) : (
+        )}
+        {isOpenAI && (
           <ProviderKey
             name="openai"
             providerLabel="OpenAI"
@@ -132,70 +138,88 @@ export function MindTab({ settings }: MindTabProps) {
             hideProviderHeader
           />
         )}
-        <p className="section-hint">Powers the reasoning behind every answer.</p>
+        {!isOllama && (
+          <p className="section-hint">Powers the reasoning behind every answer.</p>
+        )}
       </div>
 
-      <div className="section">
-        <div className="section-title" style={{ marginBottom: 14 }}>Model</div>
-        <div className="model-list">
-          {isAnthropic
-            ? CLAUDE_MODELS.map((m) => (
-                <button
-                  key={m.id}
-                  className={`model-item ${settings.selectedModel === m.id ? 'on' : ''}`}
-                  onClick={() => window.flicky.setModel(m.id)}
-                >
-                  <div className="model-radio" />
-                  <div className="model-meta">
-                    <div className="model-name">{m.name}</div>
-                    <div className="model-sub">{m.sub}</div>
-                  </div>
-                  {m.tag && <div className={`model-tag ${m.tag.cls}`}>{m.tag.label}</div>}
-                </button>
-              ))
-            : OPENAI_MODELS.map((m) => (
-                <button
-                  key={m.id}
-                  className={`model-item ${settings.selectedOpenAIModel === m.id ? 'on' : ''}`}
-                  onClick={() => window.flicky.setOpenAIModel(m.id)}
-                >
-                  <div className="model-radio" />
-                  <div className="model-meta">
-                    <div className="model-name">{m.name}</div>
-                    <div className="model-sub">{m.sub}</div>
-                  </div>
-                  {m.tag && <div className={`model-tag ${m.tag.cls}`}>{m.tag.label}</div>}
-                </button>
-              ))}
-        </div>
-      </div>
+      {isOllama ? (
+        <OllamaSection
+          ollamaEnabled={
+            (settings.localConnections ?? []).some((c) => c.enabled)
+          }
+          onToggleOllama={(enabled) => {
+            const conns = settings.localConnections ?? [];
+            conns.forEach((c) => {
+              void window.flicky.updateLocalConnection(c.id, { enabled });
+            });
+          }}
+        />
+      ) : (
+        <>
+          <div className="section">
+            <div className="section-title" style={{ marginBottom: 14 }}>Model</div>
+            <div className="model-list">
+              {isAnthropic
+                ? CLAUDE_MODELS.map((m) => (
+                    <button
+                      key={m.id}
+                      className={`model-item ${settings.selectedModel === m.id ? 'on' : ''}`}
+                      onClick={() => window.flicky.setModel(m.id)}
+                    >
+                      <div className="model-radio" />
+                      <div className="model-meta">
+                        <div className="model-name">{m.name}</div>
+                        <div className="model-sub">{m.sub}</div>
+                      </div>
+                      {m.tag && <div className={`model-tag ${m.tag.cls}`}>{m.tag.label}</div>}
+                    </button>
+                  ))
+                : OPENAI_MODELS.map((m) => (
+                    <button
+                      key={m.id}
+                      className={`model-item ${settings.selectedOpenAIModel === m.id ? 'on' : ''}`}
+                      onClick={() => window.flicky.setOpenAIModel(m.id)}
+                    >
+                      <div className="model-radio" />
+                      <div className="model-meta">
+                        <div className="model-name">{m.name}</div>
+                        <div className="model-sub">{m.sub}</div>
+                      </div>
+                      {m.tag && <div className={`model-tag ${m.tag.cls}`}>{m.tag.label}</div>}
+                    </button>
+                  ))}
+            </div>
+          </div>
 
-      <div className="section">
-        <div className="section-title" style={{ marginBottom: 6 }}>Reasoning depth</div>
-        <p className="section-hint" style={{ margin: '0 0 14px' }}>
-          How much Flicky thinks before replying.
-        </p>
-        <div className="seg">
-          <button
-            className={settings.reasoningDepth === 'off' ? 'on' : ''}
-            onClick={() => setDepth('off')}
-          >
-            Off
-          </button>
-          <button
-            className={settings.reasoningDepth === 'medium' ? 'on' : ''}
-            onClick={() => setDepth('medium')}
-          >
-            Medium
-          </button>
-          <button
-            className={settings.reasoningDepth === 'deep' ? 'on' : ''}
-            onClick={() => setDepth('deep')}
-          >
-            Deep
-          </button>
-        </div>
-      </div>
+          <div className="section">
+            <div className="section-title" style={{ marginBottom: 6 }}>Reasoning depth</div>
+            <p className="section-hint" style={{ margin: '0 0 14px' }}>
+              How much Flicky thinks before replying.
+            </p>
+            <div className="seg">
+              <button
+                className={settings.reasoningDepth === 'off' ? 'on' : ''}
+                onClick={() => setDepth('off')}
+              >
+                Off
+              </button>
+              <button
+                className={settings.reasoningDepth === 'medium' ? 'on' : ''}
+                onClick={() => setDepth('medium')}
+              >
+                Medium
+              </button>
+              <button
+                className={settings.reasoningDepth === 'deep' ? 'on' : ''}
+                onClick={() => setDepth('deep')}
+              >
+                Deep
+              </button>
+            </div>
+          </div>
+        </>
+      )}
 
       <div className="section">
         <div className="section-title" style={{ marginBottom: 14 }}>Reply tone</div>

--- a/src/renderer/components/panel/OllamaManageModal.tsx
+++ b/src/renderer/components/panel/OllamaManageModal.tsx
@@ -1,0 +1,376 @@
+import { useState, useEffect, useRef } from 'react';
+import type { LocalConnection, OllamaModelInfo, OllamaPullProgress } from '../../../shared/types';
+import { VISION_MODEL_CATALOG } from '../../../shared/vision-models';
+
+// Known vision-capable model families (mirrors ollama-api.ts constant).
+const VISION_FAMILIES = [
+  'llava', 'bakllava', 'moondream', 'cogvlm', 'minicpm-v',
+  'llava-llama3', 'llava-phi3', 'granite3.2-vision',
+  'qwen2-vl', 'qwen2.5-vl', 'qwen3-vl',
+  'llava-v1.6', 'llava-v1.5',
+  'gemma3', 'gemma4', 'mistral-small3.1', 'devstral',
+];
+
+function isVision(name: string): boolean {
+  const lower = name.toLowerCase();
+  return VISION_FAMILIES.some((f) => lower.includes(f));
+}
+
+function fmtSize(bytes?: number): string {
+  if (!bytes) return '';
+  const gb = bytes / 1_073_741_824;
+  return gb >= 1 ? `${gb.toFixed(1)} GB` : `${(bytes / 1_048_576).toFixed(0)} MB`;
+}
+
+interface OllamaManageModalProps {
+  conn: LocalConnection;
+  onClose: () => void;
+  onModelSelected: (modelId: string) => void;
+}
+
+type PullState = 'idle' | 'pulling' | 'done' | 'error';
+
+export function OllamaManageModal({ conn, onClose, onModelSelected }: OllamaManageModalProps) {
+  const [models, setModels] = useState<OllamaModelInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Pull
+  const [pullTag, setPullTag] = useState('');
+  const [pullState, setPullState] = useState<PullState>('idle');
+  const [pullProgress, setPullProgress] = useState<OllamaPullProgress | null>(null);
+  const [pullError, setPullError] = useState('');
+  const [quickPullTag, setQuickPullTag] = useState<string | null>(null);
+
+  // Delete
+  const [deleteTarget, setDeleteTarget] = useState('');
+  const [deleteConfirm, setDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  // Create
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createTag, setCreateTag] = useState('');
+  const [createJson, setCreateJson] = useState('{\n  "from": "llama3:8b"\n}');
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState('');
+
+  const bearerToken = useRef<string | undefined>(undefined);
+
+  const getBearer = async (): Promise<string | undefined> => {
+    return bearerToken.current;
+  };
+
+  const loadModels = async () => {
+    setLoading(true);
+    const list = await window.flicky.getOllamaModels(conn.url, await getBearer());
+    setModels(list);
+    setLoading(false);
+  };
+
+  useEffect(() => { void loadModels(); }, [conn.id]);
+
+  // Wire pull progress events
+  useEffect(() => {
+    const offProgress = window.flicky.onOllamaPullProgress((p) => setPullProgress(p));
+    const offComplete = window.flicky.onOllamaPullComplete(({ model }) => {
+      setPullState('done');
+      setPullTag('');
+      void loadModels();
+      // Auto-select pulled model
+      onModelSelected(model);
+    });
+    const offError = window.flicky.onOllamaPullError(({ error }) => {
+      setPullState('error');
+      setPullError(error);
+    });
+    return () => { offProgress(); offComplete(); offError(); };
+  }, [conn.id]);
+
+  const handlePull = (tag = pullTag.trim()) => {
+    if (!tag || pullState === 'pulling') return;
+    setPullState('pulling');
+    setPullProgress(null);
+    setPullError('');
+    window.flicky.pullOllamaModel(conn.url, tag, undefined);
+  };
+
+  const handleQuickPull = (tag: string) => {
+    setQuickPullTag(tag);
+    setPullTag(tag);
+    handlePull(tag);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget || deleting) return;
+    setDeleting(true);
+    try {
+      await window.flicky.deleteOllamaModel(conn.url, deleteTarget, undefined);
+      setDeleteTarget('');
+      setDeleteConfirm(false);
+      if (conn.activeModelId === deleteTarget) {
+        onModelSelected('');
+      }
+      await loadModels();
+    } catch (err) {
+      console.error('Delete failed:', err);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleCreate = async () => {
+    const tag = createTag.trim();
+    if (!tag || creating) return;
+    setCreating(true);
+    setCreateError('');
+    try {
+      await window.flicky.createOllamaModel(conn.url, tag, createJson, undefined);
+      setCreateTag('');
+      setCreateOpen(false);
+      await loadModels();
+    } catch (err) {
+      setCreateError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const pullPercent = pullProgress?.total
+    ? Math.round(((pullProgress.completed ?? 0) / pullProgress.total) * 100)
+    : null;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-box manage-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="modal-header">
+          <span>Manage Ollama</span>
+          <div className="modal-header-sub">{conn.url}</div>
+          <button className="modal-close" onClick={onClose}>✕</button>
+        </div>
+
+        {/* ── Installed models ─────────────────────────────────── */}
+        <div className="modal-section">
+          <div className="modal-section-title">Installed models</div>
+          {loading ? (
+            <div className="modal-hint">Loading…</div>
+          ) : models.length === 0 ? (
+            <div className="modal-hint">No models installed. Pull one below.</div>
+          ) : (
+            <div className="model-manage-list">
+              {models.map((m) => {
+                const vision = isVision(m.name);
+                const active = conn.activeModelId === m.name;
+                return (
+                  <button
+                    key={m.name}
+                    className={`model-manage-item ${active ? 'on' : ''}`}
+                    onClick={() => onModelSelected(active ? '' : m.name)}
+                  >
+                    <div className="model-radio" />
+                    <div className="model-meta">
+                      <div className="model-name">
+                        {m.name}
+                        {vision && <span className="vision-badge">vision</span>}
+                      </div>
+                      <div className="model-sub">{fmtSize(m.size)}</div>
+                    </div>
+                    {active && <div className="model-tag info">active</div>}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* ── Vision model catalog ─────────────────────────────── */}
+        <div className="modal-section">
+          <div className="modal-section-title">Vision-capable models</div>
+          <div className="catalog-scroll">
+            <div className="catalog-list">
+              {VISION_MODEL_CATALOG.map((entry) => {
+                const installed = models.some((m) => m.name === entry.tag);
+                const isPulling = pullState === 'pulling' && quickPullTag === entry.tag;
+                return (
+                  <div key={entry.tag} className="catalog-item">
+                    <div className="catalog-meta">
+                      <div className="catalog-name">{entry.name}</div>
+                      <div className="catalog-desc">{entry.description}</div>
+                      <div className="catalog-size">{entry.sizeLabel}</div>
+                    </div>
+                    <div className="catalog-action">
+                      {installed ? (
+                        <span className="model-tag info">installed</span>
+                      ) : (
+                        <button
+                          className="btn xs primary"
+                          disabled={pullState === 'pulling'}
+                          onClick={() => handleQuickPull(entry.tag)}
+                        >
+                          {isPulling ? 'Pulling…' : 'Pull'}
+                        </button>
+                      )}
+                      <button
+                        className="link-btn"
+                        onClick={() => window.flicky.openExternal(`https://ollama.com/library/${entry.librarySlug}`)}
+                      >
+                        Browse
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+          {pullState === 'pulling' && quickPullTag && pullProgress && (
+            <div className="pull-progress">
+              <div className="pull-status">{pullProgress.status}</div>
+              {pullPercent !== null && (
+                <>
+                  <div className="pull-bar-wrap">
+                    <div className="pull-bar" style={{ width: `${pullPercent}%` }} />
+                  </div>
+                  <div className="pull-pct">{pullPercent}%</div>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* ── Pull a model ─────────────────────────────────────── */}
+        <div className="modal-section">
+          <div className="modal-section-title">Pull a model from Ollama.com</div>
+          <div className="modal-input-row">
+            <input
+              type="text"
+              className="modal-input"
+              placeholder="Enter model tag (e.g. mistral:7b)"
+              value={pullTag}
+              onChange={(e) => { setPullTag(e.target.value); setPullState('idle'); }}
+              onKeyDown={(e) => { if (e.key === 'Enter') handlePull(); }}
+              disabled={pullState === 'pulling'}
+            />
+            <button
+              className="btn xs primary"
+              onClick={handlePull}
+              disabled={!pullTag.trim() || pullState === 'pulling'}
+            >
+              {pullState === 'pulling' ? 'Pulling…' : 'Pull'}
+            </button>
+          </div>
+
+          {pullState === 'pulling' && pullProgress && (
+            <div className="pull-progress">
+              <div className="pull-status">{pullProgress.status}</div>
+              {pullPercent !== null && (
+                <div className="pull-bar-wrap">
+                  <div className="pull-bar" style={{ width: `${pullPercent}%` }} />
+                </div>
+              )}
+              {pullPercent !== null && (
+                <div className="pull-pct">{pullPercent}%</div>
+              )}
+            </div>
+          )}
+          {pullState === 'done' && (
+            <div className="modal-hint ok">Model pulled and selected.</div>
+          )}
+          {pullState === 'error' && (
+            <div className="modal-hint err">Error: {pullError}</div>
+          )}
+          <div className="modal-hint">
+            To browse available models,{' '}
+            <button
+              className="link-btn"
+              onClick={() => window.flicky.openExternal('https://ollama.com/library')}
+            >
+              click here
+            </button>
+            .
+          </div>
+        </div>
+
+        {/* ── Delete a model ───────────────────────────────────── */}
+        <div className="modal-section">
+          <div className="modal-section-title">Delete a model</div>
+          <div className="modal-input-row">
+            <select
+              className="modal-input modal-select"
+              value={deleteTarget}
+              onChange={(e) => { setDeleteTarget(e.target.value); setDeleteConfirm(false); }}
+            >
+              <option value="">Select a model…</option>
+              {models.map((m) => (
+                <option key={m.name} value={m.name}>{m.name}</option>
+              ))}
+            </select>
+            {deleteTarget && !deleteConfirm && (
+              <button className="btn xs danger" onClick={() => setDeleteConfirm(true)}>
+                Delete
+              </button>
+            )}
+            {deleteTarget && deleteConfirm && (
+              <>
+                <button
+                  className="btn xs danger"
+                  onClick={handleDelete}
+                  disabled={deleting}
+                >
+                  {deleting ? 'Deleting…' : 'Confirm'}
+                </button>
+                <button className="btn xs subtle" onClick={() => setDeleteConfirm(false)}>
+                  Cancel
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* ── Create a model ───────────────────────────────────── */}
+        <div className="modal-section">
+          <button
+            className="modal-section-toggle"
+            onClick={() => setCreateOpen((x) => !x)}
+          >
+            <span>Create a model</span>
+            <span className="chev">{createOpen ? '▴' : '▾'}</span>
+          </button>
+
+          {createOpen && (
+            <>
+              <div className="modal-input-row" style={{ marginTop: 10 }}>
+                <input
+                  type="text"
+                  className="modal-input"
+                  placeholder="Enter model tag (e.g. my-modelfile)"
+                  value={createTag}
+                  onChange={(e) => setCreateTag(e.target.value)}
+                />
+              </div>
+              <textarea
+                className="modal-textarea"
+                rows={4}
+                value={createJson}
+                onChange={(e) => setCreateJson(e.target.value)}
+                placeholder='e.g. {"model": "my-modelfile", "from": "llama3:8b"}'
+                spellCheck={false}
+              />
+              {createError && <div className="modal-hint err">{createError}</div>}
+              <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 8 }}>
+                <button
+                  className="btn xs primary"
+                  onClick={handleCreate}
+                  disabled={!createTag.trim() || creating}
+                >
+                  {creating ? 'Creating…' : 'Create'}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="modal-footer" style={{ justifyContent: 'flex-end' }}>
+          <button className="btn xs subtle" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/panel/OllamaManageModal.tsx
+++ b/src/renderer/components/panel/OllamaManageModal.tsx
@@ -250,7 +250,7 @@ export function OllamaManageModal({ conn, onClose, onModelSelected }: OllamaMana
             />
             <button
               className="btn xs primary"
-              onClick={handlePull}
+              onClick={() => handlePull()}
               disabled={!pullTag.trim() || pullState === 'pulling'}
             >
               {pullState === 'pulling' ? 'Pulling…' : 'Pull'}

--- a/src/renderer/components/panel/OllamaSection.tsx
+++ b/src/renderer/components/panel/OllamaSection.tsx
@@ -1,0 +1,128 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { LocalConnection } from '../../../shared/types';
+import { ConnectionRow } from './ConnectionRow';
+import { AddConnectionModal } from './AddConnectionModal';
+import { OllamaManageModal } from './OllamaManageModal';
+
+interface OllamaSectionProps {
+  ollamaEnabled: boolean;
+  onToggleOllama: (enabled: boolean) => void;
+}
+
+export function OllamaSection({ ollamaEnabled, onToggleOllama }: OllamaSectionProps) {
+  const [connections, setConnections] = useState<LocalConnection[]>([]);
+  const [showModal, setShowModal] = useState(false);
+  const [editing, setEditing] = useState<LocalConnection | undefined>(undefined);
+  const [managing, setManaging] = useState<LocalConnection | undefined>(undefined);
+
+  const reload = useCallback(async () => {
+    const conns = await window.flicky.getLocalConnections();
+    setConnections(conns);
+  }, []);
+
+  useEffect(() => { void reload(); }, [reload]);
+
+  const handleSave = async (conn: LocalConnection) => {
+    setShowModal(false);
+    setEditing(undefined);
+    await reload();
+    // If this is the first connection, switch model provider to ollama
+    const all = await window.flicky.getLocalConnections();
+    if (all.length === 1) {
+      window.flicky.setMindProvider('ollama');
+    }
+  };
+
+  const handleManage = (conn: LocalConnection) => {
+    setManaging(conn);
+  };
+
+  const handleConfigure = (conn: LocalConnection) => {
+    setEditing(conn);
+    setShowModal(true);
+  };
+
+  const handleModelSelected = async (connId: string, modelId: string) => {
+    await window.flicky.updateLocalConnection(connId, { activeModelId: modelId || undefined });
+    await reload();
+    // Reflect updated conn in the manage modal
+    const updated = (await window.flicky.getLocalConnections()).find((c) => c.id === connId);
+    if (updated) setManaging(updated);
+  };
+
+  const handleToggle = async (conn: LocalConnection) => {
+    await window.flicky.updateLocalConnection(conn.id, { enabled: !conn.enabled });
+    await reload();
+  };
+
+  const handleDelete = async (conn: LocalConnection) => {
+    await window.flicky.deleteLocalConnection(conn.id);
+    setShowModal(false);
+    setEditing(undefined);
+    await reload();
+  };
+
+  return (
+    <>
+      <div className="section">
+        <div className="section-row">
+          <div className="section-title">Ollama API</div>
+          <button
+            className={`toggle-pill ${ollamaEnabled ? 'on' : ''}`}
+            onClick={() => onToggleOllama(!ollamaEnabled)}
+          />
+        </div>
+
+        <div className="section-row" style={{ marginTop: 10 }}>
+          <div className="section-sub">Manage Ollama API Connections</div>
+          <button
+            className="btn xs add"
+            onClick={() => { setEditing(undefined); setShowModal(true); }}
+          >
+            + Add Connection
+          </button>
+        </div>
+
+        {connections.length === 0 ? (
+          <div className="empty-state">
+            No connections yet. Add one to get started.
+          </div>
+        ) : (
+          <div className="conn-list">
+            {connections.map((c) => (
+              <ConnectionRow
+                key={c.id}
+                conn={c}
+                onManage={handleManage}
+                onConfigure={handleConfigure}
+                onToggle={handleToggle}
+              />
+            ))}
+          </div>
+        )}
+
+        <p className="section-hint">
+          Connect to any OpenAI-compatible local endpoint. Ollama, LM Studio, and vLLM are all
+          supported.
+        </p>
+      </div>
+
+      {showModal && (
+        <AddConnectionModal
+          existing={editing}
+          onSave={handleSave}
+          onClose={() => { setShowModal(false); setEditing(undefined); }}
+          onDelete={editing ? handleDelete : undefined}
+        />
+      )}
+
+      {managing && (
+        <OllamaManageModal
+          conn={managing}
+          onClose={() => setManaging(undefined)}
+          onModelSelected={(modelId) => void handleModelSelected(managing.id, modelId)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/renderer/styles/panel.css
+++ b/src/renderer/styles/panel.css
@@ -821,3 +821,307 @@ button.provider-pick:hover {
 @media (min-width: 1000px) {
   .main { padding: 36px 48px 44px; }
 }
+
+/* ── Local provider logo ─────────────────────────────────────────── */
+.provider-logo.local { background: #3a3a44; color: var(--fl-ink); font-size: 11px; }
+
+/* ── Toggle pill (reuses .toggle shape) ─────────────────────────── */
+.toggle-pill {
+  width: 36px; height: 22px; border-radius: 999px;
+  background: var(--fl-border-strong); position: relative;
+  cursor: pointer; flex-shrink: 0; border: none; padding: 0;
+  transition: background .15s ease;
+}
+.toggle-pill::after {
+  content: ''; position: absolute; top: 2px; left: 2px;
+  width: 18px; height: 18px; border-radius: 999px; background: #fff;
+  transition: transform .2s ease;
+  box-shadow: 0 1px 3px rgba(0,0,0,.4);
+}
+.toggle-pill.on { background: #fff; }
+.toggle-pill.on::after { background: #0f0f11; transform: translateX(14px); }
+
+/* ── Section layout helpers ─────────────────────────────────────── */
+.section-row {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px;
+}
+.section-sub {
+  font-size: 12.5px; color: var(--fl-muted); font-weight: 500;
+}
+
+/* ── Connection list ────────────────────────────────────────────── */
+.conn-list {
+  display: flex; flex-direction: column; gap: 8px;
+  margin-top: 12px;
+}
+.conn-row {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 14px;
+  background: var(--fl-surface-2);
+  border: 1px solid var(--fl-border);
+  border-radius: 12px;
+  gap: 12px;
+  transition: border-color .12s ease;
+}
+.conn-row:hover { border-color: var(--fl-border-strong); }
+.conn-row.disabled { opacity: 0.5; }
+.conn-url {
+  font-family: 'Geist Mono', ui-monospace, monospace;
+  font-size: 12px; color: var(--fl-ink-soft);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  flex: 1;
+}
+.conn-actions {
+  display: flex; align-items: center; gap: 8px; flex-shrink: 0;
+}
+.empty-state {
+  margin-top: 14px;
+  font-size: 12.5px; color: var(--fl-dim);
+  text-align: center; padding: 20px;
+  border: 1px dashed var(--fl-border);
+  border-radius: 12px;
+}
+
+/* ── Add connection modal ───────────────────────────────────────── */
+.modal-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,.6);
+  display: grid; place-items: center;
+  z-index: 1000;
+  backdrop-filter: blur(3px);
+}
+.modal-box {
+  background: var(--fl-surface);
+  border: 1px solid var(--fl-border-strong);
+  border-radius: 18px;
+  width: min(480px, calc(100vw - 48px));
+  max-height: calc(100vh - 80px);
+  overflow-y: auto;
+  padding: 24px;
+  display: flex; flex-direction: column; gap: 18px;
+}
+.modal-box::-webkit-scrollbar { width: 5px; }
+.modal-box::-webkit-scrollbar-track { background: transparent; }
+.modal-box::-webkit-scrollbar-thumb {
+  background: var(--fl-border); border-radius: 999px;
+}
+.modal-box::-webkit-scrollbar-thumb:hover { background: var(--fl-border-strong); }
+.modal-header {
+  display: flex; align-items: center; justify-content: space-between;
+  font-size: 15px; font-weight: 700; color: var(--fl-ink);
+  letter-spacing: -0.02em;
+}
+.modal-close {
+  background: transparent; border: none; padding: 4px 8px;
+  color: var(--fl-muted); cursor: pointer; font-size: 13px;
+  border-radius: 6px;
+}
+.modal-close:hover { background: var(--fl-surface-2); color: var(--fl-ink); }
+.modal-field { display: flex; flex-direction: column; gap: 8px; }
+.modal-label {
+  font-size: 11px; letter-spacing: .1em; text-transform: uppercase;
+  font-weight: 700; color: var(--fl-muted);
+}
+.modal-input {
+  width: 100%; box-sizing: border-box;
+  background: var(--fl-surface-2);
+  border: 1px solid var(--fl-border);
+  border-radius: 10px; padding: 9px 13px;
+  font: inherit; font-size: 13px;
+  color: var(--fl-ink); outline: none;
+  transition: border-color .12s ease;
+}
+.modal-input:focus { border-color: var(--fl-border-strong); }
+.modal-input-row {
+  display: flex; gap: 8px; align-items: center;
+}
+.modal-input-row .modal-input { flex: 1; }
+.modal-auth-row {
+  display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+}
+.modal-auth-row .modal-input { flex: 1; min-width: 120px; }
+.modal-hint {
+  font-size: 12px; color: var(--fl-muted); line-height: 1.5;
+}
+.modal-hint.ok { color: var(--fl-ok); }
+.modal-hint.err { color: var(--fl-danger); }
+.modal-hint code {
+  font-family: 'Geist Mono', ui-monospace, monospace;
+  font-size: 11.5px; background: var(--fl-surface-2);
+  padding: 1px 5px; border-radius: 4px;
+}
+.modal-footer {
+  display: flex; align-items: center; gap: 8px;
+  padding-top: 4px;
+  border-top: 1px solid var(--fl-border);
+}
+
+/* ── Tag chips ──────────────────────────────────────────────────── */
+.tag-list {
+  display: flex; flex-wrap: wrap; gap: 6px;
+}
+.tag-chip {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 3px 9px 3px 10px;
+  background: var(--fl-surface-2);
+  border: 1px solid var(--fl-border);
+  border-radius: 999px;
+  font-size: 12px; color: var(--fl-ink-soft);
+}
+.tag-chip button {
+  background: none; border: none; padding: 0;
+  cursor: pointer; color: var(--fl-muted); font-size: 10px;
+  line-height: 1;
+}
+.tag-chip button:hover { color: var(--fl-ink); }
+
+/* ── Danger button ──────────────────────────────────────────────── */
+.btn.danger {
+  background: transparent; border-color: var(--fl-danger);
+  color: var(--fl-danger);
+}
+.btn.danger:hover { background: var(--fl-danger-bg); }
+
+/* ── Connection row active model display ────────────────────────── */
+.conn-info { display: flex; flex-direction: column; gap: 2px; overflow: hidden; flex: 1; }
+.conn-model {
+  font-size: 11px; color: var(--fl-muted);
+  font-family: 'Geist Mono', ui-monospace, monospace;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+
+/* ── Manage Ollama modal ────────────────────────────────────────── */
+.manage-modal { width: min(680px, calc(100vw - 48px)); }
+.modal-header-sub {
+  font-size: 11px; color: var(--fl-muted);
+  font-family: 'Geist Mono', ui-monospace, monospace;
+  font-weight: 400; margin-left: 8px; flex: 1;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.modal-section {
+  display: flex; flex-direction: column; gap: 10px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--fl-border);
+}
+.modal-section:last-of-type { border-bottom: none; padding-bottom: 0; }
+.modal-section-title {
+  font-size: 11px; letter-spacing: .1em; text-transform: uppercase;
+  font-weight: 700; color: var(--fl-muted);
+}
+.modal-section-toggle {
+  display: flex; align-items: center; justify-content: space-between;
+  background: none; border: none; padding: 0;
+  font: inherit; font-size: 11px; letter-spacing: .1em; text-transform: uppercase;
+  font-weight: 700; color: var(--fl-muted);
+  cursor: pointer; width: 100%;
+}
+.modal-section-toggle:hover { color: var(--fl-ink); }
+.modal-textarea {
+  width: 100%; box-sizing: border-box;
+  background: var(--fl-surface-2);
+  border: 1px solid var(--fl-border);
+  border-radius: 10px; padding: 9px 13px;
+  font-family: 'Geist Mono', ui-monospace, monospace; font-size: 12px;
+  color: var(--fl-ink); outline: none; resize: vertical;
+  transition: border-color .12s ease;
+}
+.modal-textarea:focus { border-color: var(--fl-border-strong); }
+.modal-select {
+  appearance: none; cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%238a8a92'/%3E%3C/svg%3E");
+  background-repeat: no-repeat; background-position: right 12px center;
+  padding-right: 32px;
+}
+
+/* ── Model list in manage modal ────────────────────────────────── */
+.model-manage-list {
+  display: flex; flex-direction: column; gap: 6px; max-height: 220px;
+  overflow-y: auto; padding-right: 6px; margin-right: -6px;
+}
+.model-manage-list::-webkit-scrollbar { width: 5px; }
+.model-manage-list::-webkit-scrollbar-track { background: transparent; }
+.model-manage-list::-webkit-scrollbar-thumb {
+  background: var(--fl-border); border-radius: 999px;
+}
+.model-manage-list::-webkit-scrollbar-thumb:hover { background: var(--fl-border-strong); }
+.model-manage-item {
+  display: flex; align-items: center; gap: 12px;
+  width: 100%; padding: 10px 14px;
+  background: var(--fl-surface-2);
+  border: 1px solid var(--fl-border);
+  border-radius: 10px; cursor: pointer;
+  font: inherit; text-align: left;
+  transition: border-color .12s ease;
+}
+.model-manage-item:hover { border-color: var(--fl-border-strong); }
+.model-manage-item.on { border-color: #fff; background: rgba(255,255,255,.04); }
+.model-manage-item .model-radio {
+  width: 14px; height: 14px; border-radius: 999px;
+  border: 2px solid var(--fl-border-strong); flex-shrink: 0;
+  transition: border-color .12s, background .12s;
+}
+.model-manage-item.on .model-radio {
+  background: #fff; border-color: #fff;
+}
+
+/* ── Vision badge ───────────────────────────────────────────────── */
+.vision-badge {
+  display: inline-flex; align-items: center;
+  font-size: 9.5px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase;
+  padding: 2px 6px; border-radius: 999px; margin-left: 7px;
+  background: rgba(142, 189, 154, 0.15); color: var(--fl-ok);
+  border: 1px solid rgba(142, 189, 154, 0.3);
+}
+
+/* ── Pull progress ──────────────────────────────────────────────── */
+.pull-progress { display: flex; flex-direction: column; gap: 6px; }
+.pull-status { font-size: 12px; color: var(--fl-muted); }
+.pull-bar-wrap {
+  height: 4px; background: var(--fl-border); border-radius: 999px; overflow: hidden;
+}
+.pull-bar {
+  height: 100%; background: #fff; border-radius: 999px;
+  transition: width .3s ease;
+}
+.pull-pct { font-size: 11px; color: var(--fl-muted); text-align: right; }
+
+/* ── Inline link button ─────────────────────────────────────────── */
+.link-btn {
+  background: none; border: none; padding: 0;
+  color: var(--fl-ink); font: inherit; font-size: inherit;
+  cursor: pointer; text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.link-btn:hover { color: var(--fl-ink-soft); }
+
+/* ── Vision model catalog ────────────────────────────────────────── */
+.catalog-list {
+  display: flex; flex-direction: column; gap: 8px; margin-top: 8px;
+}
+.catalog-item {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 12px;
+  background: var(--fl-surface-2); border: 1px solid var(--fl-border);
+  border-radius: 8px; padding: 10px 12px;
+}
+.catalog-meta { flex: 1; min-width: 0; }
+.catalog-name {
+  font-size: 12.5px; font-weight: 600; color: var(--fl-ink);
+  display: flex; align-items: center; gap: 0;
+}
+.catalog-desc { font-size: 11.5px; color: var(--fl-muted); margin-top: 3px; }
+.catalog-size { font-size: 11px; color: var(--fl-dim); margin-top: 2px; }
+.catalog-action {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; flex-shrink: 0;
+}
+.catalog-scroll {
+  max-height: 300px; overflow-y: auto;
+  padding-right: 6px; margin-right: -6px;
+}
+.catalog-scroll::-webkit-scrollbar { width: 5px; }
+.catalog-scroll::-webkit-scrollbar-track { background: transparent; }
+.catalog-scroll::-webkit-scrollbar-thumb {
+  background: var(--fl-border); border-radius: 999px;
+}
+.catalog-scroll::-webkit-scrollbar-thumb:hover { background: var(--fl-border-strong); }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -38,7 +38,7 @@ export type ClaudeModel = 'claude-sonnet-4-6' | 'claude-opus-4-6';
 export type OpenAIModel = 'gpt-5' | 'gpt-5-mini' | 'gpt-4o';
 
 /** Which service backs the Mind (reasoning) capability. */
-export type MindProvider = 'anthropic' | 'openai';
+export type MindProvider = 'anthropic' | 'openai' | 'ollama';
 
 /** Extended-thinking budget mapping. */
 export type ReasoningDepth = 'off' | 'medium' | 'deep';
@@ -58,6 +58,35 @@ export interface DetectedElement {
   y: number;
   label: string;
   screenIndex: number;
+}
+
+// ── Local Connections (Ollama / OpenAI-compatible local endpoints) ─────
+
+export interface OllamaModelInfo {
+  name: string;
+  size?: number;
+  digest?: string;
+  modified_at?: string;
+}
+
+export interface OllamaPullProgress {
+  status: string;
+  completed?: number;
+  total?: number;
+  digest?: string;
+}
+
+export interface LocalConnection {
+  id: string;
+  type: 'local' | 'external';
+  label?: string;
+  url: string;
+  enabled: boolean;
+  bearerEnabled: boolean;
+  prefixId?: string;
+  modelIds: string[];
+  activeModelId?: string;
+  tags: string[];
 }
 
 // ── API Keys ───────────────────────────────────────────────────────────
@@ -159,6 +188,9 @@ export interface FlickySettings {
   /** Last known position + size of the stream window; null = auto-place. */
   streamWindowBounds: StreamWindowBounds | null;
 
+  // Local model connections
+  localConnections: LocalConnection[];
+
   // Lifecycle
   onboardingComplete: boolean;
   apiKeyStatus: ApiKeyStatus;
@@ -184,6 +216,8 @@ export const DEFAULT_SETTINGS: FlickySettings = {
   pushToTalkShortcut: 'Ctrl+Alt+X',
   streamVisibility: 'off',
   streamWindowBounds: null,
+
+  localConnections: [],
 
   onboardingComplete: false,
   apiKeyStatus: { anthropic: false, openai: false, elevenlabs: false, groq: false },
@@ -243,4 +277,22 @@ export const IPC = {
   SET_API_KEY: 'set-api-key',
   DELETE_API_KEY: 'delete-api-key',
   GET_API_KEY_STATUS: 'get-api-key-status',
+
+  // Local Connection Management
+  GET_LOCAL_CONNECTIONS: 'get-local-connections',
+  ADD_LOCAL_CONNECTION: 'add-local-connection',
+  UPDATE_LOCAL_CONNECTION: 'update-local-connection',
+  DELETE_LOCAL_CONNECTION: 'delete-local-connection',
+  TEST_LOCAL_CONNECTION: 'test-local-connection',
+  GET_OLLAMA_MODELS: 'get-ollama-models',
+  SET_LOCAL_CONNECTION_KEY: 'set-local-connection-key',
+  DELETE_LOCAL_CONNECTION_KEY: 'delete-local-connection-key',
+
+  // Ollama Model Management
+  PULL_OLLAMA_MODEL: 'pull-ollama-model',
+  OLLAMA_PULL_PROGRESS: 'ollama-pull-progress',
+  OLLAMA_PULL_COMPLETE: 'ollama-pull-complete',
+  OLLAMA_PULL_ERROR: 'ollama-pull-error',
+  DELETE_OLLAMA_MODEL: 'delete-ollama-model',
+  CREATE_OLLAMA_MODEL: 'create-ollama-model',
 } as const;

--- a/src/shared/vision-models.ts
+++ b/src/shared/vision-models.ts
@@ -1,0 +1,88 @@
+export interface VisionModelEntry {
+  tag: string;
+  name: string;
+  description: string;
+  sizeLabel: string;
+  /** Ollama.com library path for the "Browse" link */
+  librarySlug: string;
+}
+
+export const VISION_MODEL_CATALOG: VisionModelEntry[] = [
+  {
+    tag: 'qwen3-vl:8b',
+    name: 'Qwen3-VL 8B',
+    description: "Alibaba's latest vision-language model — strong OCR, charts, video frames",
+    sizeLabel: '~5 GB',
+    librarySlug: 'qwen3-vl',
+  },
+  {
+    tag: 'qwen2.5-vl:7b',
+    name: 'Qwen2.5-VL 7B',
+    description: 'Solid all-round vision model; good at document understanding',
+    sizeLabel: '~5 GB',
+    librarySlug: 'qwen2.5-vl',
+  },
+  {
+    tag: 'llava:13b',
+    name: 'LLaVA 13B',
+    description: 'Reliable visual Q&A; widely tested with Ollama',
+    sizeLabel: '~8 GB',
+    librarySlug: 'llava',
+  },
+  {
+    tag: 'llava:7b',
+    name: 'LLaVA 7B',
+    description: 'Lighter LLaVA variant — faster on modest hardware',
+    sizeLabel: '~4.5 GB',
+    librarySlug: 'llava',
+  },
+  {
+    tag: 'llava-llama3:8b',
+    name: 'LLaVA-LLaMA3 8B',
+    description: 'LLaVA fine-tuned on LLaMA 3 — improved reasoning',
+    sizeLabel: '~5 GB',
+    librarySlug: 'llava-llama3',
+  },
+  {
+    tag: 'llava-phi3:medium',
+    name: 'LLaVA-Phi3 Medium',
+    description: 'Microsoft Phi-3 backbone; efficient for mid-range GPUs',
+    sizeLabel: '~8 GB',
+    librarySlug: 'llava-phi3',
+  },
+  {
+    tag: 'minicpm-v:8b',
+    name: 'MiniCPM-V 8B',
+    description: 'Excellent at fine-grained image detail and Chinese text',
+    sizeLabel: '~5 GB',
+    librarySlug: 'minicpm-v',
+  },
+  {
+    tag: 'moondream:latest',
+    name: 'Moondream',
+    description: 'Tiny vision model (~1.6B) — very fast on CPU',
+    sizeLabel: '~1 GB',
+    librarySlug: 'moondream',
+  },
+  {
+    tag: 'granite3.2-vision:2b',
+    name: 'Granite 3.2 Vision 2B',
+    description: 'IBM Granite vision model; strong at document and chart Q&A',
+    sizeLabel: '~2 GB',
+    librarySlug: 'granite3.2-vision',
+  },
+  {
+    tag: 'gemma3:12b',
+    name: 'Gemma 3 12B',
+    description: "Google's Gemma 3 with built-in vision capability",
+    sizeLabel: '~8 GB',
+    librarySlug: 'gemma3',
+  },
+  {
+    tag: 'gemma4:e4b',
+    name: 'Gemma 4 E4B',
+    description: "Google's Gemma 4 edge model — vision + text, efficient on CPU",
+    sizeLabel: '~9.5 GB',
+    librarySlug: 'gemma4',
+  },
+];


### PR DESCRIPTION
## Summary

  - Adds a **Local** provider path in the Mind tab, routing
  inference to any Ollama or OpenAI-compatible local endpoint (LM Studio,
  vLLM, xAI, etc.)
  - New `OllamaAPI` service handles connection testing, model listing,
  pull/delete/create, and streaming chat — with URL normalization to fix
  external provider path doubling
  - Full connection manager UI: `AddConnectionModal`, `ConnectionRow`,
  `OllamaSection`, and `OllamaManageModal` with an 11-entry vision model
  catalog
  - Stream runs to EOS with no timeout or token cap; PTT `AbortSignal` is
  the sole cancellation mechanism — prevents silent hangs on CPU-only
  inference
  - Manage modal polished: widened to 680px, catalog and installed model
  list both scroll with a consistent thin 5px pill scrollbar

  ## Test plan

  - [ ] Launch dev build; navigate Mind tab → Local — OllamaSection renders
  - [ ] Add Connection → Verify returns green + model count
  - [ ] Save; row appears with toggle, Manage, Configure actions
  - [ ] Trigger PTT → Ollama responds via streaming chat
  - [ ] Add external connection with bearer token → Verify succeeds (no 404)
  - [ ] Manage modal → all three scroll regions use thin pill scrollbar
  - [ ] Quick-pull a catalog model → progress bar updates; model appears in
  list
  - [ ] Kill Ollama mid-stream → error surfaces gracefully, no crash
  - [ ] `npm run typecheck` — zero errors