### PR TITLE
fix(linux): fall back to software rendering after repeated GPU crashes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,16 +8,21 @@ import * as chatHistory from './services/chat-history-store';
 import * as settingsStore from './services/settings-store';
 import { setApiKey, getApiKey, deleteApiKey } from './services/key-store';
 import { OllamaAPI } from './services/ollama-api';
-import { applyGpuFallback, watchGpuProcess } from './services/gpu-guard';
+import { initGpuGuard, confirmGpuHealthy } from './services/gpu-guard';
 import { randomUUID } from 'crypto';
-
-// Must run before the app is ready, and before any window exists.
-applyGpuFallback();
 
 // Prevent multiple instances
 const gotLock = app.requestSingleInstanceLock();
 if (!gotLock) {
   app.quit();
+}
+
+// Must run before the app is ready: the switches it may set only apply
+// pre-ready, and the GPU failure it counts happens during startup, so
+// the listener has to exist before then. Gated on the instance lock so
+// a duplicate launch that's about to quit never touches the counter.
+if (gotLock) {
+  initGpuGuard();
 }
 
 let tray: Tray | null = null;
@@ -108,7 +113,7 @@ function sendToAll(channel: string, ...args: unknown[]): void {
 // ── App Lifecycle ──────────────────────────────────────────────────────
 
 app.whenReady().then(() => {
-  watchGpuProcess();
+  confirmGpuHealthy();
 
   // Initialize companion manager
   companion = new CompanionManager({

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,7 +8,11 @@ import * as chatHistory from './services/chat-history-store';
 import * as settingsStore from './services/settings-store';
 import { setApiKey, getApiKey, deleteApiKey } from './services/key-store';
 import { OllamaAPI } from './services/ollama-api';
+import { applyGpuFallback, watchGpuProcess } from './services/gpu-guard';
 import { randomUUID } from 'crypto';
+
+// Must run before the app is ready, and before any window exists.
+applyGpuFallback();
 
 // Prevent multiple instances
 const gotLock = app.requestSingleInstanceLock();
@@ -104,6 +108,8 @@ function sendToAll(channel: string, ...args: unknown[]): void {
 // ── App Lifecycle ──────────────────────────────────────────────────────
 
 app.whenReady().then(() => {
+  watchGpuProcess();
+
   // Initialize companion manager
   companion = new CompanionManager({
     onVoiceStateChanged: (state) => {

--- a/src/main/services/gpu-guard.ts
+++ b/src/main/services/gpu-guard.ts
@@ -14,28 +14,52 @@ import { writeFileAtomic } from './fs-util';
  *   [FATAL:gpu_data_manager_impl_private.cc] GPU process isn't usable. Goodbye.
  *
  * There's no way to detect that before it happens, so instead we count
- * GPU process crashes across runs. Once a machine has crashed enough
- * times to look chronic rather than incidental, the next launch starts
- * with hardware acceleration off and the app comes up in software
- * rendering instead of dying.
+ * GPU process crashes across runs and degrade in tiers on the next
+ * launch:
  *
- * A run that stays up without a GPU crash clears the counter, so a
- * one-off crash during a driver update doesn't permanently downgrade
- * a machine that's otherwise fine.
+ *   tier 0  hardware acceleration, the normal path
+ *   tier 1  software rendering (`disableHardwareAcceleration`)
+ *   tier 2  tier 1 plus an unsandboxed GPU process
+ *
+ * Tier 2 exists because tier 1 does not stop the GPU process from
+ * launching — it only skips GL/driver init. That fixes a crash during
+ * Mesa driver setup, but not one caused by the GPU sandbox failing to
+ * start the process at all, which is a commonly reported cause of this
+ * same error signature. If a machine keeps crashing while already in
+ * software rendering, the sandbox is the next suspect.
  */
 
-/** Consecutive-ish GPU crashes before we stop asking for the GPU. */
-const CRASH_THRESHOLD = 3;
+/** Crash counts at which each tier engages. */
+const TIER_1_THRESHOLD = 3;
+const TIER_2_THRESHOLD = 6;
 
 /** Uptime without a GPU crash that counts as "this machine is fine". */
 const HEALTHY_UPTIME_MS = 60_000;
+
+/**
+ * Reasons that indicate a broken GPU stack. Deliberately excludes
+ * `clean-exit` and `killed` (normal teardown, OS/OOM kill, driver reset)
+ * and `oom` — counting those would let ordinary shutdowns accumulate
+ * into a permanent downgrade on a perfectly healthy machine.
+ */
+const FAILURE_REASONS = new Set(['crashed', 'abnormal-exit', 'launch-failed', 'integrity-failure']);
 
 interface GpuState {
   crashes: number;
 }
 
+/** Tier applied this run, so the reset logic knows not to undo itself. */
+let activeTier = 0;
+
+/** Keeps a failed write from spamming the log on every crash event. */
+let writeErrorLogged = false;
+
+/** Set once the GPU has failed at least once during this run. */
+let crashedThisRun = false;
+
 function getStatePath(): string {
-  // Safe before `ready`: userData resolves from the app name alone.
+  // Safe before `ready`: userData is derived from the app name, and
+  // nothing in this app calls setName/setPath.
   return path.join(app.getPath('userData'), 'gpu-state.json');
 }
 
@@ -43,7 +67,11 @@ function readState(): GpuState {
   try {
     const raw = fs.readFileSync(getStatePath(), 'utf-8');
     const parsed = JSON.parse(raw) as Partial<GpuState>;
-    return { crashes: typeof parsed.crashes === 'number' ? parsed.crashes : 0 };
+    const crashes = Number(parsed?.crashes);
+    // Number.isFinite rather than typeof: NaN is a number, and NaN
+    // compares false against every threshold, which would disable the
+    // fallback entirely.
+    return { crashes: Number.isFinite(crashes) ? Math.max(0, Math.floor(crashes)) : 0 };
   } catch {
     return { crashes: 0 };
   }
@@ -52,60 +80,90 @@ function readState(): GpuState {
 function writeState(state: GpuState): void {
   try {
     writeFileAtomic(getStatePath(), JSON.stringify(state));
-  } catch {
-    // A missing counter only costs us the fallback on the next launch;
-    // never let it stop the app from starting.
+  } catch (err) {
+    // A counter we can't persist only costs us the fallback on the next
+    // launch; never let it stop the app from starting. Log it once so
+    // it's diagnosable rather than invisible.
+    if (!writeErrorLogged) {
+      writeErrorLogged = true;
+      console.error('[Flicky] Could not persist GPU crash state:', err);
+    }
   }
 }
 
+function tierFor(crashes: number): number {
+  if (crashes >= TIER_2_THRESHOLD) return 2;
+  if (crashes >= TIER_1_THRESHOLD) return 1;
+  return 0;
+}
+
+function applyTier(tier: number): void {
+  if (tier >= 1) app.disableHardwareAcceleration();
+  if (tier >= 2) app.commandLine.appendSwitch('disable-gpu-sandbox');
+}
+
 /**
- * Decide whether to ask for hardware acceleration at all. Must run
- * before `app.whenReady()` — `disableHardwareAcceleration` is a no-op
- * (and throws in some Electron versions) once the app is ready.
+ * Decide how much to degrade, and start counting crashes.
+ *
+ * Must run before `app.whenReady()`: `disableHardwareAcceleration` and
+ * `commandLine.appendSwitch` only take effect pre-ready, and the crash
+ * this guards against happens during startup, so the listener has to be
+ * attached before ready or it misses the very events it exists to count.
  */
-export function applyGpuFallback(): void {
+export function initGpuGuard(): void {
   // Escape hatch so a user hitting this can confirm it's the GPU
   // without waiting for the counter to trip.
-  if (process.env.FLICKY_DISABLE_GPU === '1') {
-    console.log('[Flicky] FLICKY_DISABLE_GPU=1 — starting with software rendering.');
-    app.disableHardwareAcceleration();
-    return;
+  const forced = process.env.FLICKY_DISABLE_GPU;
+  if (forced === '1' || forced === '2') {
+    activeTier = Number(forced);
+    console.log(`[Flicky] FLICKY_DISABLE_GPU=${forced} — starting at GPU fallback tier ${activeTier}.`);
+    applyTier(activeTier);
+  } else {
+    const { crashes } = readState();
+    activeTier = tierFor(crashes);
+    if (activeTier > 0) {
+      console.log(
+        `[Flicky] GPU process failed ${crashes} time(s) on previous runs — ` +
+          `starting at fallback tier ${activeTier}. Delete gpu-state.json in the ` +
+          'app data directory to retry hardware acceleration.',
+      );
+      applyTier(activeTier);
+    }
   }
-
-  const { crashes } = readState();
-  if (crashes >= CRASH_THRESHOLD) {
-    console.log(
-      `[Flicky] GPU process crashed ${crashes} time(s) on previous runs — ` +
-        'starting with software rendering. Delete gpu-state.json in the app ' +
-        'data directory to retry hardware acceleration.',
-    );
-    app.disableHardwareAcceleration();
-  }
-}
-
-/**
- * Track GPU process crashes so the next launch can act on them.
- * Call once, after the app is ready.
- */
-export function watchGpuProcess(): void {
-  let crashedThisRun = false;
 
   app.on('child-process-gone', (_event, details) => {
     if (details.type !== 'GPU') return;
+    if (!FAILURE_REASONS.has(details.reason)) return;
 
     crashedThisRun = true;
     const next = readState().crashes + 1;
     writeState({ crashes: next });
     console.error(
       `[Flicky] GPU process gone (reason=${details.reason}, ` +
-        `exitCode=${details.exitCode}). Crash count is now ${next}.`,
+        `exitCode=${details.exitCode}). Failure count is now ${next}` +
+        (tierFor(next) > activeTier ? `; tier ${tierFor(next)} will apply on next launch.` : '.'),
     );
   });
+}
+
+/**
+ * Clear the counter once a run has proven itself stable. Call after the
+ * app is ready.
+ *
+ * Only meaningful at tier 0. Above it the GPU is quiet *because* we
+ * degraded, so treating that as proof the machine is healthy would
+ * re-enable acceleration on the next launch and crash it again, forever.
+ * Recovery at tier 1+ is the documented gpu-state.json deletion.
+ */
+export function confirmGpuHealthy(): void {
+  if (activeTier > 0) return;
 
   setTimeout(() => {
+    // A run that recovered from a GPU failure is not a clean run — the
+    // count has to survive so repeated failures still add up.
     if (crashedThisRun) return;
     if (readState().crashes === 0) return;
-    console.log('[Flicky] GPU has been stable this run — clearing the crash counter.');
+    console.log('[Flicky] GPU has been stable this run — clearing the failure counter.');
     writeState({ crashes: 0 });
   }, HEALTHY_UPTIME_MS).unref?.();
 }

--- a/src/main/services/gpu-guard.ts
+++ b/src/main/services/gpu-guard.ts
@@ -1,0 +1,111 @@
+import { app } from 'electron';
+import * as fs from 'fs';
+import * as path from 'path';
+import { writeFileAtomic } from './fs-util';
+
+/**
+ * Self-healing fallback for machines where the GPU process can't start.
+ *
+ * On some Linux setups (AMD integrated graphics on Mesa in particular)
+ * Chromium's GPU process fails to launch, retries, and then takes the
+ * whole app down with:
+ *
+ *   [ERROR:gpu_process_host.cc] GPU process launch failed: error_code=1002
+ *   [FATAL:gpu_data_manager_impl_private.cc] GPU process isn't usable. Goodbye.
+ *
+ * There's no way to detect that before it happens, so instead we count
+ * GPU process crashes across runs. Once a machine has crashed enough
+ * times to look chronic rather than incidental, the next launch starts
+ * with hardware acceleration off and the app comes up in software
+ * rendering instead of dying.
+ *
+ * A run that stays up without a GPU crash clears the counter, so a
+ * one-off crash during a driver update doesn't permanently downgrade
+ * a machine that's otherwise fine.
+ */
+
+/** Consecutive-ish GPU crashes before we stop asking for the GPU. */
+const CRASH_THRESHOLD = 3;
+
+/** Uptime without a GPU crash that counts as "this machine is fine". */
+const HEALTHY_UPTIME_MS = 60_000;
+
+interface GpuState {
+  crashes: number;
+}
+
+function getStatePath(): string {
+  // Safe before `ready`: userData resolves from the app name alone.
+  return path.join(app.getPath('userData'), 'gpu-state.json');
+}
+
+function readState(): GpuState {
+  try {
+    const raw = fs.readFileSync(getStatePath(), 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<GpuState>;
+    return { crashes: typeof parsed.crashes === 'number' ? parsed.crashes : 0 };
+  } catch {
+    return { crashes: 0 };
+  }
+}
+
+function writeState(state: GpuState): void {
+  try {
+    writeFileAtomic(getStatePath(), JSON.stringify(state));
+  } catch {
+    // A missing counter only costs us the fallback on the next launch;
+    // never let it stop the app from starting.
+  }
+}
+
+/**
+ * Decide whether to ask for hardware acceleration at all. Must run
+ * before `app.whenReady()` — `disableHardwareAcceleration` is a no-op
+ * (and throws in some Electron versions) once the app is ready.
+ */
+export function applyGpuFallback(): void {
+  // Escape hatch so a user hitting this can confirm it's the GPU
+  // without waiting for the counter to trip.
+  if (process.env.FLICKY_DISABLE_GPU === '1') {
+    console.log('[Flicky] FLICKY_DISABLE_GPU=1 — starting with software rendering.');
+    app.disableHardwareAcceleration();
+    return;
+  }
+
+  const { crashes } = readState();
+  if (crashes >= CRASH_THRESHOLD) {
+    console.log(
+      `[Flicky] GPU process crashed ${crashes} time(s) on previous runs — ` +
+        'starting with software rendering. Delete gpu-state.json in the app ' +
+        'data directory to retry hardware acceleration.',
+    );
+    app.disableHardwareAcceleration();
+  }
+}
+
+/**
+ * Track GPU process crashes so the next launch can act on them.
+ * Call once, after the app is ready.
+ */
+export function watchGpuProcess(): void {
+  let crashedThisRun = false;
+
+  app.on('child-process-gone', (_event, details) => {
+    if (details.type !== 'GPU') return;
+
+    crashedThisRun = true;
+    const next = readState().crashes + 1;
+    writeState({ crashes: next });
+    console.error(
+      `[Flicky] GPU process gone (reason=${details.reason}, ` +
+        `exitCode=${details.exitCode}). Crash count is now ${next}.`,
+    );
+  });
+
+  setTimeout(() => {
+    if (crashedThisRun) return;
+    if (readState().crashes === 0) return;
+    console.log('[Flicky] GPU has been stable this run — clearing the crash counter.');
+    writeState({ crashes: 0 });
+  }, HEALTHY_UPTIME_MS).unref?.();
+}


### PR DESCRIPTION
Found while looking into #5. **Unproven against real hardware — see the testing section before merging.**

## the bug

On some Linux setups (AMD integrated graphics on Mesa in the reported case) the GPU process fails to launch, Chromium retries, and then kills the app:

```
[ERROR:gpu_process_host.cc(976)] GPU process launch failed: error_code=1002
[WARNING:gpu_process_host.cc(1416)] The GPU process has crashed 1 time(s)
... (repeats 6 times) ...
[FATAL:gpu_data_manager_impl_private.cc(423)] GPU process isn't usable. Goodbye.
```

There is no fallback for this anywhere in `src/main` right now: no `app.disableHardwareAcceleration()`, no `app.commandLine.appendSwitch`. So the app is unusable on affected machines, and the only workaround is passing `--disable-gpu` by hand, which tends to break the transparent overlay windows rather than help.

## the fix

You can't detect a GPU that will fail before it fails, so this counts failures across runs and degrades in tiers on the next launch:

| tier | trigger | behavior |
|---|---|---|
| 0 | default | hardware acceleration |
| 1 | 3 failures | `disableHardwareAcceleration()` |
| 2 | 6 failures | tier 1 + `disable-gpu-sandbox` |

Tier 2 matters because **`disableHardwareAcceleration()` does not stop the GPU process from launching** — it only skips GL/driver init. That fixes a crash *during Mesa driver setup*, but not one where the sandbox fails to start the process at all, which is a commonly reported cause of this same error signature. If a machine keeps failing while already in software rendering, the sandbox is the next suspect. This tier is reasoned from the error class, not confirmed on hardware.

Counting rules that matter:

- Only `crashed`, `abnormal-exit`, `launch-failed`, `integrity-failure` count. `clean-exit` and `killed` are normal teardown and an OOM kill — counting those would let ordinary shutdowns accumulate into a permanent downgrade on a healthy machine.
- The counter resets only at tier 0, and only after a run that saw no GPU failure at all. Resetting while the fallback is active would clear the count *because* we degraded, then re-enable acceleration next launch and crash again forever.
- Recovery from tier 1+ is the documented `gpu-state.json` deletion, printed in the log line.
- `FLICKY_DISABLE_GPU=1` or `=2` forces a tier.

Runs pre-ready (the switches only apply before ready, and the failure being counted happens during startup), gated on the single-instance lock so a duplicate launch never touches the counter.

## testing

`npm run typecheck` passes. `npm run lint` fails on master too, unrelated: eslint 9 wants a flat `eslint.config.js` and the repo doesn't have one.

**Not runtime-tested against a failing GPU** — I don't have that hardware. `FLICKY_DISABLE_GPU=1 npm start` exercises the fallback path on any machine, which is worth doing before merge.

## the open question that decides whether this works at all

It is **unverified whether Electron emits `child-process-gone` to JS before Chromium's `LOG(FATAL)` aborts the process.** If `GpuDataManagerImpl`'s observer runs first, the app dies before JS ever sees the events, the counter never increments, and the fallback never engages. The writes are synchronous with an fsync so each captured event has the best chance of landing, but that's mitigation, not proof.

One test on an affected machine settles it: launch, let it die, then check whether `gpu-state.json` in the app data directory has a non-zero count. If it's absent or zero, this approach doesn't work and the fallback needs to be driven by something other than crash events — likely a "did the last launch reach ready?" sentinel written at startup and cleared on clean shutdown.

## also unresolved

Nothing gates the overlay windows in fallback mode. They're fullscreen, `transparent: true`, `alwaysOnTop: 'screen-saver'`, one per display, fed cursor positions every 16ms. Electron on Linux has a history of transparent windows rendering opaque black without GPU compositing — a black fullscreen always-on-top overlay would be a worse outcome than the crash. Worth checking on the target config; if it's a problem, skipping overlay creation at tier 1+ is the obvious follow-up.
